### PR TITLE
Adding service test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 
 go:
-  1.41.4
+  - 1.14.4
 
 stages:
   - test
@@ -30,11 +30,11 @@ jobs:
       - docker build -t gojektech/albatross:latest .
       - docker images
       - docker push gojektech/albatross:latest
-    - |
-      ([ ! -z "$TRAVIS_TAG" ] && \
-      docker tag gojektech/albatross:latest gojektech/albatross:$TRAVIS_TAG  && \ 
-      docker push gojektech/albatross:$TRAVIS_TAG) || true
-    - |
-      [ ! -z "$TRAVIS_COMMIT" ] && \
-      docker tag gojektech/albatross:latest gojektech/albatross:$TRAVIS_COMMIT && \
-      docker push gojektech/albatross:$TRAVIS_COMMIT
+      - |
+        ([ ! -z "$TRAVIS_TAG" ] && \
+        docker tag gojektech/albatross:latest gojektech/albatross:$TRAVIS_TAG  && \
+        docker push gojektech/albatross:$TRAVIS_TAG) || true
+      - |
+        [ ! -z "$TRAVIS_COMMIT" ] && \
+        docker tag gojektech/albatross:latest gojektech/albatross:$TRAVIS_COMMIT && \
+        docker push gojektech/albatross:$TRAVIS_COMMIT

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Albatross
 
+[![Build Status](https://travis-ci.org/gojekfarm/albatross.svg?branch=master)](https://travis-ci.org/gojekfarm/albatross)
+
 Albatross wraps the helm package to expose helm operations as HTTP APIs.
 
 ## Getting Started

--- a/api/install/install.go
+++ b/api/install/install.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -39,6 +40,10 @@ type Response struct {
 	Status  string `json:"status,omitempty"`
 	Data    string `json:"data,omitempty"`
 	Release `json:"-"`
+}
+
+type service interface {
+	Install(ctx context.Context, req Request) (Response, error)
 }
 
 func Handler(service service) http.Handler {

--- a/api/install/service.go
+++ b/api/install/service.go
@@ -9,12 +9,9 @@ import (
 	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 )
 
-// TODO: Move the service interface to a common place for all apis
-type service interface {
-	Install(ctx context.Context, req Request) (Response, error)
+type Service struct {
+	cli helmcli.Client
 }
-
-type Service struct{}
 
 func (s Service) Install(ctx context.Context, req Request) (Response, error) {
 	installflags := flags.InstallFlags{
@@ -22,7 +19,7 @@ func (s Service) Install(ctx context.Context, req Request) (Response, error) {
 		Version:     req.Flags.Version,
 		GlobalFlags: req.Flags.GlobalFlags,
 	}
-	icli := helmcli.NewInstaller(installflags)
+	icli := s.cli.NewInstaller(installflags)
 	release, err := icli.Install(ctx, req.Name, req.Chart, req.Values)
 	if err != nil {
 		return Response{}, err

--- a/api/install/service.go
+++ b/api/install/service.go
@@ -22,7 +22,7 @@ func (s Service) Install(ctx context.Context, req Request) (Response, error) {
 	icli := s.cli.NewInstaller(installflags)
 	release, err := icli.Install(ctx, req.Name, req.Chart, req.Values)
 	if err != nil {
-		return Response{}, err
+		return responseWithStatus(release), err
 	}
 	resp := Response{Status: release.Info.Status.String(), Release: releaseInfo(release)}
 	if req.Flags.DryRun {
@@ -41,4 +41,16 @@ func releaseInfo(release *release.Release) Release {
 		Chart:      release.Chart.ChartFullPath(),
 		AppVersion: release.Chart.AppVersion(),
 	}
+}
+
+func responseWithStatus(rel *release.Release) Response {
+	resp := Response{}
+	if rel != nil && rel.Info != nil {
+		resp.Status = rel.Info.Status.String()
+	}
+	return resp
+}
+
+func NewService(cli helmcli.Client) Service {
+	return Service{cli}
 }

--- a/api/install/service_test.go
+++ b/api/install/service_test.go
@@ -1,0 +1,106 @@
+package install
+
+import (
+	"context"
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
+
+	"github.com/gojekfarm/albatross/pkg/helmcli"
+	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
+)
+
+// To satisfy the client interface, we have to define all methods(NewUpgrade, NewInstaller) on the mock struct
+// TODO: Find a way to isolate interface only for upgrade
+type mockHelmClient struct{ mock.Mock }
+
+func (m *mockHelmClient) NewUpgrader(fl flags.UpgradeFlags) helmcli.Upgrader {
+	return m.Called().Get(0).(helmcli.Upgrader)
+}
+
+func (m *mockHelmClient) NewInstaller(fl flags.InstallFlags) helmcli.Installer {
+	return m.Called().Get(0).(helmcli.Installer)
+}
+
+type mockInstaller struct{ mock.Mock }
+
+func (m *mockInstaller) Install(ctx context.Context, relName, chart string, values map[string]interface{}) (*release.Release, error) {
+	args := m.Called(ctx, relName, chart, values)
+	if len(args) < 2 {
+		log.Fatalf("error while mocking response for install")
+	}
+	return args.Get(0).(*release.Release), args.Error(1)
+}
+
+func TestShouldReturnErrorOnInvalidChart(t *testing.T) {
+	helmcli := new(mockHelmClient)
+	inc := new(mockInstaller)
+	service := NewService(helmcli)
+	ctx := context.Background()
+	req := Request{Name: "invalid_release", Chart: "stable/invalid_chart"}
+	helmcli.On("NewInstaller").Return(inc)
+	release := &release.Release{Info: &release.Info{Status: release.StatusFailed}}
+	inc.On("Install", ctx, req.Name, req.Chart, req.Values).Return(release, errors.New("failed to download invalid-chart"))
+
+	resp, err := service.Install(ctx, req)
+
+	assert.EqualError(t, err, "failed to download invalid-chart")
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, "failed", resp.Status)
+	helmcli.AssertExpectations(t)
+	inc.AssertExpectations(t)
+}
+
+func TestShouldReturnValidResponseOnSuccess(t *testing.T) {
+	helmcli := new(mockHelmClient)
+	inc := new(mockInstaller)
+	service := NewService(helmcli)
+	ctx := context.Background()
+	req := Request{Name: "invalid_release", Chart: "stable/invalid_chart"}
+	helmcli.On("NewInstaller").Return(inc)
+	chartloader, err := loader.Loader("../testdata/albatross")
+	if err != nil {
+		panic("Could not load chart")
+	}
+
+	chart, err := chartloader.Load()
+	if err != nil {
+		panic("Unable to load chart")
+	}
+
+	release := &release.Release{
+		Name:      "test-release",
+		Namespace: "test-namespace",
+		Version:   1,
+		Info: &release.Info{
+			FirstDeployed: time.Now(),
+			Status:        release.StatusDeployed,
+		},
+		Chart: chart,
+	}
+
+	inc.On("Install", ctx, req.Name, req.Chart, req.Values).Return(release, nil)
+
+	resp, err := service.Install(ctx, req)
+
+	assert.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, resp.Name, release.Name)
+	assert.Equal(t, resp.Namespace, release.Namespace)
+	assert.Equal(t, resp.Version, release.Version)
+	assert.Equal(t, resp.Status, release.Info.Status.String())
+	assert.Equal(t, resp.Chart, release.Chart.ChartFullPath())
+	assert.Equal(t, resp.Updated, release.Info.FirstDeployed.Local().Time)
+	assert.Equal(t, resp.AppVersion, release.Chart.AppVersion())
+	assert.Empty(t, resp.Error)
+	helmcli.AssertExpectations(t)
+	inc.AssertExpectations(t)
+}

--- a/api/install/service_test.go
+++ b/api/install/service_test.go
@@ -29,6 +29,10 @@ func (m *mockHelmClient) NewInstaller(fl flags.InstallFlags) helmcli.Installer {
 	return m.Called().Get(0).(helmcli.Installer)
 }
 
+func (m *mockHelmClient) NewLister(fl flags.ListFlags) helmcli.Lister {
+	return m.Called().Get(0).(helmcli.Lister)
+}
+
 type mockInstaller struct{ mock.Mock }
 
 func (m *mockInstaller) Install(ctx context.Context, relName, chart string, values map[string]interface{}) (*release.Release, error) {

--- a/api/list/list.go
+++ b/api/list/list.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -39,6 +40,10 @@ type Release struct {
 type Response struct {
 	Error    string    `json:"error,omitempty"`
 	Releases []Release `json:"releases,omitempty"`
+}
+
+type service interface {
+	List(ctx context.Context, req Request) (Response, error)
 }
 
 func Handler(service service) http.Handler {

--- a/api/list/service.go
+++ b/api/list/service.go
@@ -9,17 +9,15 @@ import (
 	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 )
 
-type service interface {
-	List(ctx context.Context, req Request) (Response, error)
+type Service struct {
+	cli helmcli.Client
 }
-
-type Service struct{}
 
 func (s Service) List(ctx context.Context, req Request) (Response, error) {
 	listflags := flags.ListFlags{
 		GlobalFlags: req.Flags.GlobalFlags,
 	}
-	lcli := helmcli.NewLister(listflags)
+	lcli := s.cli.NewLister(listflags)
 	releases, err := lcli.List(ctx)
 	if err != nil {
 		return Response{}, err
@@ -44,4 +42,8 @@ func releaseInfo(release *release.Release) Release {
 		Chart:      release.Chart.ChartFullPath(),
 		AppVersion: release.Chart.AppVersion(),
 	}
+}
+
+func NewService(cli helmcli.Client) Service {
+	return Service{cli}
 }

--- a/api/list/service_test.go
+++ b/api/list/service_test.go
@@ -1,0 +1,92 @@
+package list
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
+
+	"github.com/gojekfarm/albatross/pkg/helmcli"
+	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
+)
+
+// To satisfy the client interface, we have to define all methods(NewUpgrade, NewInstaller) on the mock struct
+// TODO: Find a way to isolate interface only for upgrade
+type mockHelmClient struct{ mock.Mock }
+
+func (m *mockHelmClient) NewUpgrader(fl flags.UpgradeFlags) helmcli.Upgrader {
+	return m.Called().Get(0).(helmcli.Upgrader)
+}
+
+func (m *mockHelmClient) NewInstaller(fl flags.InstallFlags) helmcli.Installer {
+	return m.Called().Get(0).(helmcli.Installer)
+}
+
+func (m *mockHelmClient) NewLister(fl flags.ListFlags) helmcli.Lister {
+	return m.Called().Get(0).(helmcli.Lister)
+}
+
+type mockLister struct{ mock.Mock }
+
+func (m *mockLister) List(ctx context.Context) ([]*release.Release, error) {
+	args := m.Called(ctx)
+	if len(args) < 1 {
+		log.Fatalf("error while mocking response for list")
+	}
+	return args.Get(0).([]*release.Release), args.Error(1)
+}
+
+func TestShouldReturnValidResponseOnSuccess(t *testing.T) {
+	helmcli := new(mockHelmClient)
+	lic := new(mockLister)
+	service := NewService(helmcli)
+	ctx := context.Background()
+	req := Request{Flags: Flags{Deployed: true}}
+	helmcli.On("NewLister").Return(lic)
+	chartloader, err := loader.Loader("../testdata/albatross")
+	if err != nil {
+		panic("Could not load chart")
+	}
+
+	chart, err := chartloader.Load()
+	if err != nil {
+		panic("Unable to load chart")
+	}
+
+	releases := []*release.Release{
+		{
+			Name:      "test-release",
+			Namespace: "test-namespace",
+			Version:   1,
+			Info: &release.Info{
+				FirstDeployed: time.Now(),
+				Status:        release.StatusDeployed,
+			},
+			Chart: chart,
+		},
+	}
+
+	lic.On("List", ctx).Return(releases, nil)
+
+	resp, err := service.List(ctx, req)
+
+	assert.NoError(t, err)
+	require.NotNil(t, resp)
+	rel := resp.Releases[0]
+	assert.Equal(t, rel.Name, releases[0].Name)
+	assert.Equal(t, rel.Namespace, releases[0].Namespace)
+	assert.Equal(t, rel.Version, releases[0].Version)
+	assert.Equal(t, rel.Status, releases[0].Info.Status)
+	assert.Equal(t, rel.Chart, releases[0].Chart.ChartFullPath())
+	assert.Equal(t, rel.Updated, releases[0].Info.FirstDeployed.Local().Time)
+	assert.Equal(t, rel.AppVersion, releases[0].Chart.AppVersion())
+	assert.Empty(t, resp.Error)
+	helmcli.AssertExpectations(t)
+	lic.AssertExpectations(t)
+}

--- a/api/upgrade/service.go
+++ b/api/upgrade/service.go
@@ -9,10 +9,6 @@ import (
 	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 )
 
-type upgrader interface {
-	Upgrade(ctx context.Context, release, chart string, values map[string]interface{}) (*release.Release, error)
-}
-
 type Service struct {
 	cli helmcli.Client
 }

--- a/api/upgrade/service.go
+++ b/api/upgrade/service.go
@@ -9,11 +9,13 @@ import (
 	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 )
 
-type service interface {
-	Upgrade(ctx context.Context, req Request) (Response, error)
+type upgrader interface {
+	Upgrade(ctx context.Context, release, chart string, values map[string]interface{}) (*release.Release, error)
 }
 
-type Service struct{}
+type Service struct {
+	cli helmcli.Client
+}
 
 func (s Service) Upgrade(ctx context.Context, req Request) (Response, error) {
 	upgradeflags := flags.UpgradeFlags{
@@ -23,10 +25,10 @@ func (s Service) Upgrade(ctx context.Context, req Request) (Response, error) {
 		GlobalFlags: req.Flags.GlobalFlags,
 	}
 
-	ucli := helmcli.NewUpgrader(upgradeflags)
+	ucli := s.cli.NewUpgrader(upgradeflags)
 	release, err := ucli.Upgrade(ctx, req.Name, req.Chart, req.Values)
 	if err != nil {
-		return Response{}, err
+		return responseWithStatus(release), err
 	}
 	resp := Response{Status: release.Info.Status.String(), Release: releaseInfo(release)}
 	if req.Flags.DryRun {
@@ -45,4 +47,16 @@ func releaseInfo(release *release.Release) Release {
 		Chart:      release.Chart.ChartFullPath(),
 		AppVersion: release.Chart.AppVersion(),
 	}
+}
+
+func responseWithStatus(rel *release.Release) Response {
+	resp := Response{}
+	if rel != nil && rel.Info != nil {
+		resp.Status = rel.Info.Status.String()
+	}
+	return resp
+}
+
+func NewService(cli helmcli.Client) Service {
+	return Service{cli}
 }

--- a/api/upgrade/service_test.go
+++ b/api/upgrade/service_test.go
@@ -29,6 +29,10 @@ func (m *mockHelmClient) NewInstaller(fl flags.InstallFlags) helmcli.Installer {
 	return m.Called().Get(0).(helmcli.Installer)
 }
 
+func (m *mockHelmClient) NewLister(fl flags.ListFlags) helmcli.Lister {
+	return m.Called().Get(0).(helmcli.Lister)
+}
+
 type mockUpgrader struct{ mock.Mock }
 
 func (m *mockUpgrader) Upgrade(ctx context.Context, relName, chart string, values map[string]interface{}) (*release.Release, error) {

--- a/api/upgrade/service_test.go
+++ b/api/upgrade/service_test.go
@@ -6,13 +6,38 @@ import (
 	"log"
 	"testing"
 
-	"github.com/gojekfarm/albatross/pkg/helmcli"
-	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/time"
+
+	"github.com/gojekfarm/albatross/pkg/helmcli"
+	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 )
+
+// To satisfy the client interface, we have to define all methods(NewUpgrade, NewInstaller) on the mock struct
+// TODO: Find a way to isolate interface only for upgrade
+type mockHelmClient struct{ mock.Mock }
+
+func (m *mockHelmClient) NewUpgrader(fl flags.UpgradeFlags) helmcli.Upgrader {
+	return m.Called().Get(0).(helmcli.Upgrader)
+}
+
+func (m *mockHelmClient) NewInstaller(fl flags.InstallFlags) helmcli.Installer {
+	return m.Called().Get(0).(helmcli.Installer)
+}
+
+type mockUpgrader struct{ mock.Mock }
+
+func (m *mockUpgrader) Upgrade(ctx context.Context, relName, chart string, values map[string]interface{}) (*release.Release, error) {
+	args := m.Called(ctx, relName, chart, values)
+	if len(args) < 2 {
+		log.Fatalf("error while mocking response for upgrade")
+	}
+	return args.Get(0).(*release.Release), args.Error(1)
+}
 
 func TestShouldReturnErrorOnInvalidChart(t *testing.T) {
 	helmcli := new(mockHelmClient)
@@ -34,18 +59,48 @@ func TestShouldReturnErrorOnInvalidChart(t *testing.T) {
 	upgc.AssertExpectations(t)
 }
 
-type mockHelmClient struct{ mock.Mock }
-
-func (m *mockHelmClient) NewUpgrader(fl flags.UpgradeFlags) helmcli.Upgrader {
-	return m.Called().Get(0).(upgrader)
-}
-
-type mockUpgrader struct{ mock.Mock }
-
-func (m *mockUpgrader) Upgrade(ctx context.Context, relName, chart string, values map[string]interface{}) (*release.Release, error) {
-	args := m.Called(ctx, relName, chart, values)
-	if len(args) < 2 {
-		log.Fatalf("error while mocking response for upgrade")
+func TestShouldReturnValidResponseOnSuccess(t *testing.T) {
+	helmcli := new(mockHelmClient)
+	upgc := new(mockUpgrader)
+	service := NewService(helmcli)
+	ctx := context.Background()
+	req := Request{Name: "invalid_release", Chart: "stable/invalid_chart"}
+	helmcli.On("NewUpgrader").Return(upgc)
+	chartloader, err := loader.Loader("../testdata/albatross")
+	if err != nil {
+		panic("Could not load chart")
 	}
-	return args.Get(0).(*release.Release), args.Error(1)
+
+	chart, err := chartloader.Load()
+	if err != nil {
+		panic("Unable to load chart")
+	}
+
+	release := &release.Release{
+		Name:      "test-release",
+		Namespace: "test-namespace",
+		Version:   1,
+		Info: &release.Info{
+			FirstDeployed: time.Now(),
+			Status:        release.StatusDeployed,
+		},
+		Chart: chart,
+	}
+
+	upgc.On("Upgrade", ctx, req.Name, req.Chart, req.Values).Return(release, nil)
+
+	resp, err := service.Upgrade(ctx, req)
+
+	assert.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, resp.Name, release.Name)
+	assert.Equal(t, resp.Namespace, release.Namespace)
+	assert.Equal(t, resp.Version, release.Version)
+	assert.Equal(t, resp.Status, release.Info.Status.String())
+	assert.Equal(t, resp.Chart, release.Chart.ChartFullPath())
+	assert.Equal(t, resp.Updated, release.Info.FirstDeployed.Local().Time)
+	assert.Equal(t, resp.AppVersion, release.Chart.AppVersion())
+	assert.Empty(t, resp.Error)
+	helmcli.AssertExpectations(t)
+	upgc.AssertExpectations(t)
 }

--- a/api/upgrade/service_test.go
+++ b/api/upgrade/service_test.go
@@ -1,0 +1,51 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/gojekfarm/albatross/pkg/helmcli"
+	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+func TestShouldReturnErrorOnInvalidChart(t *testing.T) {
+	helmcli := new(mockHelmClient)
+	upgc := new(mockUpgrader)
+	service := NewService(helmcli)
+	ctx := context.Background()
+	req := Request{Name: "invalid_release", Chart: "stable/invalid_chart"}
+	helmcli.On("NewUpgrader").Return(upgc)
+	release := &release.Release{Info: &release.Info{Status: release.StatusFailed}}
+	upgc.On("Upgrade", ctx, req.Name, req.Chart, req.Values).Return(release, errors.New("failed to download invalid-chart"))
+
+	resp, err := service.Upgrade(ctx, req)
+
+	assert.EqualError(t, err, "failed to download invalid-chart")
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, "failed", resp.Status)
+	helmcli.AssertExpectations(t)
+	upgc.AssertExpectations(t)
+}
+
+type mockHelmClient struct{ mock.Mock }
+
+func (m *mockHelmClient) NewUpgrader(fl flags.UpgradeFlags) helmcli.Upgrader {
+	return m.Called().Get(0).(upgrader)
+}
+
+type mockUpgrader struct{ mock.Mock }
+
+func (m *mockUpgrader) Upgrade(ctx context.Context, relName, chart string, values map[string]interface{}) (*release.Release, error) {
+	args := m.Called(ctx, relName, chart, values)
+	if len(args) < 2 {
+		log.Fatalf("error while mocking response for upgrade")
+	}
+	return args.Get(0).(*release.Release), args.Error(1)
+}

--- a/cmd/albatross/albatross.go
+++ b/cmd/albatross/albatross.go
@@ -32,9 +32,9 @@ func startServer() {
 	logger.Setup("debug")
 	cli := helmcli.New()
 
-	installHandler := install.Handler(install.Service{})
+	installHandler := install.Handler(install.NewService(cli))
 	upgradeHandler := upgrade.Handler(upgrade.NewService(cli))
-	listHandler := list.Handler(list.Service{})
+	listHandler := list.Handler(list.NewService(cli))
 
 	router.Handle("/ping", ContentTypeMiddle(api.Ping())).Methods(http.MethodGet)
 	router.Handle("/list", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)

--- a/cmd/albatross/albatross.go
+++ b/cmd/albatross/albatross.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gojekfarm/albatross/api/install"
 	"github.com/gojekfarm/albatross/api/list"
 	"github.com/gojekfarm/albatross/api/upgrade"
+	"github.com/gojekfarm/albatross/pkg/helmcli"
 	"github.com/gojekfarm/albatross/pkg/logger"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -29,9 +30,10 @@ func ContentTypeMiddle(next http.Handler) http.Handler {
 func startServer() {
 	router := mux.NewRouter()
 	logger.Setup("debug")
+	cli := helmcli.New()
 
 	installHandler := install.Handler(install.Service{})
-	upgradeHandler := upgrade.Handler(upgrade.Service{})
+	upgradeHandler := upgrade.Handler(upgrade.NewService(cli))
 	listHandler := list.Handler(list.Service{})
 
 	router.Handle("/ping", ContentTypeMiddle(api.Ping())).Methods(http.MethodGet)

--- a/pkg/helmcli/client.go
+++ b/pkg/helmcli/client.go
@@ -1,0 +1,49 @@
+package helmcli
+
+import (
+	"context"
+
+	"github.com/gojekfarm/albatross/pkg/helmcli/config"
+	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/release"
+)
+
+type Client interface {
+	NewUpgrader(flags.UpgradeFlags) Upgrader
+}
+
+type Upgrader interface {
+	Upgrade(ctx context.Context, relName, chartName string, values map[string]interface{}) (*release.Release, error)
+}
+
+func New() Client {
+	return helmClient{}
+}
+
+type helmClient struct{}
+
+func (c helmClient) NewUpgrader(flg flags.UpgradeFlags) Upgrader {
+	//TODO: ifpossible envconfig could be moved to actionconfig new, remove pointer usage of globalflags
+	envconfig := config.NewEnvConfig(&flg.GlobalFlags)
+	actionconfig := config.NewActionConfig(envconfig, &flg.GlobalFlags)
+
+	upgrade := action.NewUpgrade(actionconfig.Configuration)
+	history := action.NewHistory(actionconfig.Configuration)
+	installer := NewInstaller(flags.InstallFlags{
+		DryRun:      flg.DryRun,
+		Version:     flg.Version,
+		GlobalFlags: flg.GlobalFlags,
+	})
+
+	upgrade.Namespace = flg.Namespace
+	upgrade.Install = flg.Install
+	upgrade.DryRun = flg.DryRun
+
+	return &upgrader{
+		action:      upgrade,
+		envSettings: envconfig.EnvSettings,
+		history:     history,
+		installer:   installer,
+	}
+}

--- a/pkg/helmcli/install.go
+++ b/pkg/helmcli/install.go
@@ -8,32 +8,14 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
-
-	"github.com/gojekfarm/albatross/pkg/helmcli/config"
-	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 )
 
-type Installer struct {
+type installer struct {
 	action      *action.Install
 	envSettings *cli.EnvSettings
 }
 
-// NewInstaller returns a new instance of Installer struct
-func NewInstaller(flg flags.InstallFlags) *Installer {
-	envconfig := config.NewEnvConfig(&flg.GlobalFlags)
-	actionconfig := config.NewActionConfig(envconfig, &flg.GlobalFlags)
-
-	install := action.NewInstall(actionconfig.Configuration)
-	install.Namespace = flg.Namespace
-	install.DryRun = flg.DryRun
-
-	return &Installer{
-		action:      install,
-		envSettings: envconfig.EnvSettings,
-	}
-}
-
-func (i *Installer) Install(ctx context.Context, relName, chartName string, values map[string]interface{}) (*release.Release, error) {
+func (i *installer) Install(ctx context.Context, relName, chartName string, values map[string]interface{}) (*release.Release, error) {
 	i.action.ReleaseName = relName
 
 	chart, err := i.loadChart(chartName)
@@ -44,7 +26,7 @@ func (i *Installer) Install(ctx context.Context, relName, chartName string, valu
 	return i.action.Run(chart, values)
 }
 
-func (i *Installer) loadChart(chartName string) (*chart.Chart, error) {
+func (i *installer) loadChart(chartName string) (*chart.Chart, error) {
 	cp, err := i.action.LocateChart(chartName, i.envSettings)
 	if err != nil {
 		return nil, err

--- a/pkg/helmcli/install_test.go
+++ b/pkg/helmcli/install_test.go
@@ -1,0 +1,68 @@
+package helmcli
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+)
+
+func fakeInstallConfiguration(t *testing.T) *action.Configuration {
+	return &action.Configuration{
+		Releases: storage.Init(driver.NewMemory()),
+		KubeClient: &kubefake.FailingKubeClient{
+			PrintingKubeClient: kubefake.PrintingKubeClient{
+				Out: ioutil.Discard,
+			},
+		},
+		Capabilities: chartutil.DefaultCapabilities,
+		Log: func(format string, v ...interface{}) {
+			t.Helper()
+			t.Logf(format, v...)
+		},
+	}
+
+}
+
+func TestInstallShouldFailForInvalidChart(t *testing.T) {
+	config := fakeInstallConfiguration(t)
+	u := &installer{
+		action:      action.NewInstall(config),
+		envSettings: cli.New(),
+	}
+
+	values := map[string]interface{}{
+		"test": "test",
+	}
+
+	// TODO: See if we can override registry client to mock this instead of reyling on filesystem
+	_, err := u.Install(context.Background(), "test-release", "../../api/testdata/albatrossdne", values)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, "path \"../../api/testdata/albatrossdne\" not found")
+}
+
+func TestInstallShouldReturnInstalledReleaseOnSuccess(t *testing.T) {
+	config := fakeInstallConfiguration(t)
+
+	u := &installer{
+		action:      action.NewInstall(config),
+		envSettings: cli.New(),
+	}
+
+	values := map[string]interface{}{
+		"test": "test",
+	}
+
+	release, err := u.Install(context.Background(), "test-release", "../../api/testdata/albatross", values)
+
+	assert.NoError(t, err)
+	assert.Equal(t, release.Name, "test-release")
+}

--- a/pkg/helmcli/list.go
+++ b/pkg/helmcli/list.go
@@ -6,37 +6,14 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
-
-	"github.com/gojekfarm/albatross/pkg/helmcli/config"
-	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 )
 
-// Lister acts as an entrypoint for the list action
-type Lister struct {
+type lister struct {
 	action      *action.List
 	envSettings *cli.EnvSettings
 }
 
-// NewLister returns a new Lister instance
-func NewLister(flg flags.ListFlags) *Lister {
-	envconfig := config.NewEnvConfig(&flg.GlobalFlags)
-	actionconfig := config.NewActionConfig(envconfig, &flg.GlobalFlags)
-
-	list := action.NewList(actionconfig.Configuration)
-	list.AllNamespaces = flg.AllNamespaces
-	list.Deployed = flg.Deployed
-	list.Failed = flg.Failed
-	list.Pending = flg.Pending
-	list.Uninstalling = flg.Uninstalling
-	list.Uninstalled = flg.Uninstalled
-
-	return &Lister{
-		action:      list,
-		envSettings: envconfig.EnvSettings,
-	}
-}
-
 // List runs the list operation
-func (l *Lister) List(ctx context.Context) ([]*release.Release, error) {
+func (l *lister) List(ctx context.Context) ([]*release.Release, error) {
 	return l.action.Run()
 }

--- a/pkg/helmcli/list_test.go
+++ b/pkg/helmcli/list_test.go
@@ -1,0 +1,59 @@
+package helmcli
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	"helm.sh/helm/v3/pkg/time"
+)
+
+func fakeListConfiguration(t *testing.T) *action.Configuration {
+	return &action.Configuration{
+		Releases: storage.Init(driver.NewMemory()),
+		KubeClient: &kubefake.FailingKubeClient{
+			PrintingKubeClient: kubefake.PrintingKubeClient{
+				Out: ioutil.Discard,
+			},
+		},
+		Capabilities: chartutil.DefaultCapabilities,
+		Log: func(format string, v ...interface{}) {
+			t.Helper()
+			t.Logf(format, v...)
+		},
+	}
+
+}
+
+func TestListShouldReturnListOfReleasesOnSuccess(t *testing.T) {
+	config := fakeInstallConfiguration(t)
+	// Mark that the release is already created
+	existingRelease := &release.Release{
+		Name:      "test-release",
+		Namespace: "test-namespace",
+		Version:   1,
+		Info: &release.Info{
+			FirstDeployed: time.Now(),
+			Status:        release.StatusDeployed,
+		},
+	}
+	config.Releases.Create(existingRelease)
+
+	l := &lister{
+		action:      action.NewList(config),
+		envSettings: cli.New(),
+	}
+
+	releases, err := l.List(context.Background())
+
+	assert.NoError(t, err)
+	assert.Equal(t, releases[0].Name, "test-release")
+}

--- a/pkg/helmcli/upgrade.go
+++ b/pkg/helmcli/upgrade.go
@@ -10,12 +10,9 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
-
-	"github.com/gojekfarm/albatross/pkg/helmcli/config"
-	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 )
 
-type Upgrader struct {
+type upgrader struct {
 	action      *action.Upgrade
 	history     *action.History
 	envSettings *cli.EnvSettings
@@ -26,33 +23,8 @@ type installer interface {
 	Install(ctx context.Context, relName string, chartName string, values map[string]interface{}) (*release.Release, error)
 }
 
-func NewUpgrader(flg flags.UpgradeFlags) *Upgrader {
-	//TODO: ifpossible envconfig could be moved to actionconfig new, remove pointer usage of globalflags
-	envconfig := config.NewEnvConfig(&flg.GlobalFlags)
-	actionconfig := config.NewActionConfig(envconfig, &flg.GlobalFlags)
-
-	upgrade := action.NewUpgrade(actionconfig.Configuration)
-	history := action.NewHistory(actionconfig.Configuration)
-	installer := NewInstaller(flags.InstallFlags{
-		DryRun:      flg.DryRun,
-		Version:     flg.Version,
-		GlobalFlags: flg.GlobalFlags,
-	})
-
-	upgrade.Namespace = flg.Namespace
-	upgrade.Install = flg.Install
-	upgrade.DryRun = flg.DryRun
-
-	return &Upgrader{
-		action:      upgrade,
-		envSettings: envconfig.EnvSettings,
-		history:     history,
-		installer:   installer,
-	}
-}
-
 // Upgrade executes the upgrade action
-func (u *Upgrader) Upgrade(ctx context.Context, relName, chartName string, values map[string]interface{}) (*release.Release, error) {
+func (u *upgrader) Upgrade(ctx context.Context, relName, chartName string, values map[string]interface{}) (*release.Release, error) {
 	// Install the release first if install is set to true
 	if u.action.Install {
 		u.history.Max = 1
@@ -76,7 +48,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, relName, chartName string, value
 	return u.action.Run(relName, chart, values)
 }
 
-func (u *Upgrader) loadChart(chartName string) (*chart.Chart, error) {
+func (u *upgrader) loadChart(chartName string) (*chart.Chart, error) {
 	cp, err := u.action.LocateChart(chartName, u.envSettings)
 	if err != nil {
 		return nil, err

--- a/pkg/helmcli/upgrade.go
+++ b/pkg/helmcli/upgrade.go
@@ -16,11 +16,7 @@ type upgrader struct {
 	action      *action.Upgrade
 	history     *action.History
 	envSettings *cli.EnvSettings
-	installer   installer
-}
-
-type installer interface {
-	Install(ctx context.Context, relName string, chartName string, values map[string]interface{}) (*release.Release, error)
+	installer   Installer
 }
 
 // Upgrade executes the upgrade action

--- a/pkg/helmcli/upgrade_test.go
+++ b/pkg/helmcli/upgrade_test.go
@@ -1,0 +1,137 @@
+package helmcli
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli"
+	kubefake "helm.sh/helm/v3/pkg/kube/fake"
+	"helm.sh/helm/v3/pkg/release"
+	"helm.sh/helm/v3/pkg/storage"
+	"helm.sh/helm/v3/pkg/storage/driver"
+	"helm.sh/helm/v3/pkg/time"
+)
+
+func fakeActionConfiguration(t *testing.T) *action.Configuration {
+	return &action.Configuration{
+		Releases: storage.Init(driver.NewMemory()),
+		KubeClient: &kubefake.FailingKubeClient{
+			PrintingKubeClient: kubefake.PrintingKubeClient{
+				Out: ioutil.Discard,
+			},
+		},
+		Capabilities: chartutil.DefaultCapabilities,
+		Log: func(format string, v ...interface{}) {
+			t.Helper()
+			t.Logf(format, v...)
+		},
+	}
+
+}
+
+func TestShouldFailForNonExistentReleaseWithoutInstall(t *testing.T) {
+	config := fakeActionConfiguration(t)
+	u := &upgrader{
+		action:      action.NewUpgrade(config),
+		history:     action.NewHistory(config),
+		envSettings: cli.New(),
+		installer: &installer{
+			action:      action.NewInstall(config),
+			envSettings: cli.New(),
+		},
+	}
+
+	values := map[string]interface{}{
+		"test": "test",
+	}
+	_, err := u.Upgrade(context.Background(), "test-release", "../../api/testdata/albatross", values)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, "\"test-release\" has no deployed releases")
+}
+
+func TestShouldSucceedForNonExistentReleaseWithInstall(t *testing.T) {
+	config := fakeActionConfiguration(t)
+	u := &upgrader{
+		action:      action.NewUpgrade(config),
+		history:     action.NewHistory(config),
+		envSettings: cli.New(),
+		installer: &installer{
+			action:      action.NewInstall(config),
+			envSettings: cli.New(),
+		},
+	}
+
+	u.action.Install = true
+
+	values := map[string]interface{}{
+		"test": "test",
+	}
+	release, err := u.Upgrade(context.Background(), "test-release", "../../api/testdata/albatross", values)
+
+	assert.NoError(t, err)
+	assert.Equal(t, release.Name, "test-release")
+}
+
+func TestShouldFailForInvalidChart(t *testing.T) {
+	config := fakeActionConfiguration(t)
+	u := &upgrader{
+		action:      action.NewUpgrade(config),
+		history:     action.NewHistory(config),
+		envSettings: cli.New(),
+		installer: &installer{
+			action:      action.NewInstall(config),
+			envSettings: cli.New(),
+		},
+	}
+
+	values := map[string]interface{}{
+		"test": "test",
+	}
+
+	// TODO: See if we can override registry client to mock this instead of reyling on filesystem
+	_, err := u.Upgrade(context.Background(), "test-release", "../../api/testdata/albatrossdne", values)
+
+	assert.Error(t, err)
+	assert.EqualError(t, err, "error loading chart: path \"../../api/testdata/albatrossdne\" not found")
+}
+
+func TestShouldReturnUpgradedReleaseOnSuccess(t *testing.T) {
+	config := fakeActionConfiguration(t)
+
+	// Mark that the release is already created
+	existingRelease := &release.Release{
+		Name:      "test-release",
+		Namespace: "test-namespace",
+		Version:   1,
+		Info: &release.Info{
+			FirstDeployed: time.Now(),
+			Status:        release.StatusDeployed,
+		},
+	}
+	config.Releases.Create(existingRelease)
+
+	u := &upgrader{
+		action:      action.NewUpgrade(config),
+		history:     action.NewHistory(config),
+		envSettings: cli.New(),
+		installer: &installer{
+			action:      action.NewInstall(config),
+			envSettings: cli.New(),
+		},
+	}
+
+	values := map[string]interface{}{
+		"test": "test",
+	}
+
+	release, err := u.Upgrade(context.Background(), "test-release", "../../api/testdata/albatross", values)
+
+	assert.NoError(t, err)
+	assert.Equal(t, release.Name, existingRelease.Name)
+	assert.Equal(t, release.Version, existingRelease.Version+1)
+}

--- a/pkg/helmcli/upgrade_test.go
+++ b/pkg/helmcli/upgrade_test.go
@@ -16,7 +16,7 @@ import (
 	"helm.sh/helm/v3/pkg/time"
 )
 
-func fakeActionConfiguration(t *testing.T) *action.Configuration {
+func fakeUpgradeConfiguration(t *testing.T) *action.Configuration {
 	return &action.Configuration{
 		Releases: storage.Init(driver.NewMemory()),
 		KubeClient: &kubefake.FailingKubeClient{
@@ -33,8 +33,8 @@ func fakeActionConfiguration(t *testing.T) *action.Configuration {
 
 }
 
-func TestShouldFailForNonExistentReleaseWithoutInstall(t *testing.T) {
-	config := fakeActionConfiguration(t)
+func TestUpgradeShouldFailForNonExistentReleaseWithoutInstall(t *testing.T) {
+	config := fakeUpgradeConfiguration(t)
 	u := &upgrader{
 		action:      action.NewUpgrade(config),
 		history:     action.NewHistory(config),
@@ -54,8 +54,8 @@ func TestShouldFailForNonExistentReleaseWithoutInstall(t *testing.T) {
 	assert.EqualError(t, err, "\"test-release\" has no deployed releases")
 }
 
-func TestShouldSucceedForNonExistentReleaseWithInstall(t *testing.T) {
-	config := fakeActionConfiguration(t)
+func TestUpgradeShouldSucceedForNonExistentReleaseWithInstall(t *testing.T) {
+	config := fakeUpgradeConfiguration(t)
 	u := &upgrader{
 		action:      action.NewUpgrade(config),
 		history:     action.NewHistory(config),
@@ -77,8 +77,8 @@ func TestShouldSucceedForNonExistentReleaseWithInstall(t *testing.T) {
 	assert.Equal(t, release.Name, "test-release")
 }
 
-func TestShouldFailForInvalidChart(t *testing.T) {
-	config := fakeActionConfiguration(t)
+func TestUpgradeShouldFailForInvalidChart(t *testing.T) {
+	config := fakeUpgradeConfiguration(t)
 	u := &upgrader{
 		action:      action.NewUpgrade(config),
 		history:     action.NewHistory(config),
@@ -100,8 +100,8 @@ func TestShouldFailForInvalidChart(t *testing.T) {
 	assert.EqualError(t, err, "error loading chart: path \"../../api/testdata/albatrossdne\" not found")
 }
 
-func TestShouldReturnUpgradedReleaseOnSuccess(t *testing.T) {
-	config := fakeActionConfiguration(t)
+func TestUpgradeShouldReturnUpgradedReleaseOnSuccess(t *testing.T) {
+	config := fakeUpgradeConfiguration(t)
 
 	// Mark that the release is already created
 	existingRelease := &release.Release{


### PR DESCRIPTION
-  [x] Expose functionality from helmcli as interfaces
- [x] This refactoring should enable us to write tests for servies along with handlers of upgrader/install/list
- [ ] We should compute test coverage
- [ ] Integrate [codecov](https://codecov.io/) in readme
- [x] Integrate travis CI status in readme