### PR TITLE
Fix: Usage of version flag for install and upgrade

### DIFF
--- a/pkg/helmcli/client.go
+++ b/pkg/helmcli/client.go
@@ -56,6 +56,7 @@ func (c helmClient) NewUpgrader(flg flags.UpgradeFlags) (Upgrader, error) {
 	upgrade.Namespace = flg.Namespace
 	upgrade.Install = flg.Install
 	upgrade.DryRun = flg.DryRun
+	upgrade.Version = flg.Version
 
 	return &upgrader{
 		action:      upgrade,
@@ -76,6 +77,7 @@ func (c helmClient) NewInstaller(flg flags.InstallFlags) (Installer, error) {
 	install := action.NewInstall(actionconfig.Configuration)
 	install.Namespace = flg.Namespace
 	install.DryRun = flg.DryRun
+	install.Version = flg.Version
 
 	return &installer{
 		action:      install,

--- a/pkg/helmcli/client_test.go
+++ b/pkg/helmcli/client_test.go
@@ -11,26 +11,56 @@ import (
 
 type TestSuite struct {
 	suite.Suite
-	c       Client
-	version string
+	c Client
 }
 
 func (s *TestSuite) SetupTest() {
 	s.c = New()
-	s.version = "0.1.0"
 }
 
 func (s *TestSuite) TestNewUpgraderSetsChartOptionsUsingFlagValues() {
 	t := s.T()
+	version := "0.1.0"
+	dryRun := false
 	install := false
-	flg := flags.UpgradeFlags{
-		Version: s.version,
-		Install: install,
+	globalFlags := flags.GlobalFlags{
+		Namespace: "namespace",
 	}
-	u, _ := s.c.NewUpgrader(flg)
-	newUpgrader, _ := u.(*upgrader)
-	assert.Equal(t, s.version, newUpgrader.action.Version)
+	flg := flags.UpgradeFlags{
+		Version:     version,
+		Install:     install,
+		DryRun:      dryRun,
+		GlobalFlags: globalFlags,
+	}
+	u, err := s.c.NewUpgrader(flg)
+	newUpgrader, ok := u.(*upgrader)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, version, newUpgrader.action.Version)
 	assert.Equal(t, install, newUpgrader.action.Install)
+	assert.Equal(t, dryRun, newUpgrader.action.DryRun)
+	assert.Equal(t, globalFlags.Namespace, newUpgrader.action.Namespace)
+}
+
+func (s *TestSuite) TestNewInstallerSetsChartOptionsUsingFlagValues() {
+	t := s.T()
+	version := "0.1.0"
+	dryRun := false
+	globalFlags := flags.GlobalFlags{
+		Namespace: "namespace",
+	}
+	flg := flags.InstallFlags{
+		Version:     version,
+		DryRun:      dryRun,
+		GlobalFlags: globalFlags,
+	}
+	i, err := s.c.NewInstaller(flg)
+	newInstaller, ok := i.(*installer)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, version, newInstaller.action.Version)
+	assert.Equal(t, dryRun, newInstaller.action.DryRun)
+	assert.Equal(t, globalFlags.Namespace, newInstaller.action.Namespace)
 }
 
 func TestHandler(t *testing.T) {

--- a/pkg/helmcli/client_test.go
+++ b/pkg/helmcli/client_test.go
@@ -1,0 +1,38 @@
+package helmcli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
+)
+
+type TestSuite struct {
+	suite.Suite
+	c       Client
+	version string
+}
+
+func (s *TestSuite) SetupTest() {
+	s.c = New()
+	s.version = "0.1.0"
+}
+
+func (s *TestSuite) TestNewUpgraderSetsChartOptionsUsingFlagValues() {
+	t := s.T()
+	install := false
+	flg := flags.UpgradeFlags{
+		Version: s.version,
+		Install: install,
+	}
+	u, _ := s.c.NewUpgrader(flg)
+	newUpgrader, _ := u.(*upgrader)
+	assert.Equal(t, s.version, newUpgrader.action.Version)
+	assert.Equal(t, install, newUpgrader.action.Install)
+}
+
+func TestHandler(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}


### PR DESCRIPTION
Currently the version flag isn't being passed on to helm cli. Fixed it.
Added tests to check setting of flags like version, namespace and dryrun