### PR TITLE
Feature/update routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 bin/
 vendor/
 *.swp
+cmd/albatross/__debug_bin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: clean check-quality build test golangci
+all: clean check-quality build test golangci update-doc
 
 ALL_PACKAGES=$(shell go list ./...)
 SOURCE_DIRS=$(shell go list ./... | cut -d "/" -f4 | uniq)

--- a/api/install/install.go
+++ b/api/install/install.go
@@ -14,6 +14,12 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const (
+	CLUSTER   string = "cluster"
+	NAMESPACE string = "namespace"
+	RELEASE   string = "release_name"
+)
+
 // Request is the body for insatlling a release
 // swagger:model installRequestBody
 type Request struct {
@@ -70,17 +76,17 @@ type service interface {
 }
 
 // Handler handles an install request
-// swagger:operation PUT /releases/{kube_context}/{namespace}/{release_name} release installOperation
+// swagger:operation PUT /releases/{cluster}/{namespace}/{release_name} release installOperation
 //
-// Install helm release at the specified location
 //
 // ---
+// summary: Install helm release at the specified cluster and namespace
 // consumes:
 // - application/json
 // produces:
 // - application/json
 // parameters:
-// - name: kube_context
+// - name: cluster
 //   in: path
 //   required: true
 //   default: minikube
@@ -126,7 +132,7 @@ func Handler(service service) http.Handler {
 			return
 		}
 		values := mux.Vars(r)
-		req.Flags.KubeContext = values["kube_context"]
+		req.Flags.KubeContext = values["cluster"]
 		req.Flags.Namespace = values["namespace"]
 		req.Name = values["release_name"]
 		resp, err := service.Install(r.Context(), req)

--- a/api/install/install_api_test.go
+++ b/api/install/install_api_test.go
@@ -46,7 +46,7 @@ func (s *InstallerTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
 	router := mux.NewRouter()
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodPut)
+	router.Handle("/releases/{cluster}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodPut)
 	s.server = httptest.NewServer(router)
 }
 

--- a/api/install/install_api_test.go
+++ b/api/install/install_api_test.go
@@ -46,7 +46,7 @@ func (s *InstallerTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
 	router := mux.NewRouter()
-	router.Handle("/releases/{cluster}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodPut)
+	router.Handle("/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}", Handler(s.mockService)).Methods(http.MethodPut)
 	s.server = httptest.NewServer(router)
 }
 
@@ -54,7 +54,7 @@ func (s *InstallerTestSuite) TestShouldReturnDeployedStatusOnSuccessfulInstall()
 	chartName := "stable/redis-ha"
 	body := fmt.Sprintf(`{"chart":"%s", "values": {"replicas": 2}, "flags": {}}`, chartName)
 
-	req, _ := http.NewRequest("PUT", fmt.Sprintf("%s/releases/minikube/albatross/redis-v5", s.server.URL), strings.NewReader(body))
+	req, _ := http.NewRequest("PUT", fmt.Sprintf("%s/clusters/minikube/namespaces/albatross/releases/redis-v5", s.server.URL), strings.NewReader(body))
 	response := Response{
 		Status: release.StatusDeployed.String(),
 	}
@@ -86,7 +86,7 @@ func (s *InstallerTestSuite) TestShouldReturnInternalServerErrorOnFailure() {
 	chartName := "stable/redis-ha"
 	body := fmt.Sprintf(`{"chart":"%s"}`, chartName)
 
-	req, _ := http.NewRequest("PUT", fmt.Sprintf("%s/releases/minikube/albatross/redis-v5", s.server.URL), strings.NewReader(body))
+	req, _ := http.NewRequest("PUT", fmt.Sprintf("%s/clusters/minikube/namespaces/albatross/releases/redis-v5", s.server.URL), strings.NewReader(body))
 	requestStruct := Request{
 		Chart: chartName,
 		Name:  "redis-v5",
@@ -113,7 +113,7 @@ func (s *InstallerTestSuite) TestReturnShouldBadRequestOnInvalidRequest() {
 	chartName := "stable/redis-ha"
 	body := fmt.Sprintf(`{"chart":"%s}`, chartName)
 
-	req, _ := http.NewRequest("PUT", fmt.Sprintf("%s/releases/minikube/albatross/redis-v5", s.server.URL), strings.NewReader(body))
+	req, _ := http.NewRequest("PUT", fmt.Sprintf("%s/clusters/minikube/namespaces/albatross/releases/redis-v5", s.server.URL), strings.NewReader(body))
 
 	resp, err := http.DefaultClient.Do(req)
 	assert.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)

--- a/api/list/list.go
+++ b/api/list/list.go
@@ -102,6 +102,8 @@ type service interface {
 // responses:
 //   '200':
 //    "$ref": "#/responses/listResponse"
+//   '204':
+//    description: No releases found
 //   '400':
 //    "$ref": "#/responses/listResponse"
 //   '404':
@@ -123,6 +125,11 @@ func Handler(service service) http.Handler {
 		resp, err := service.List(r.Context(), req)
 		if err != nil {
 			respondListError(w, "error while listing charts: %v", err)
+			return
+		}
+
+		if resp.Releases == nil || len(resp.Releases) == 0 {
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 
@@ -179,6 +186,8 @@ func Handler(service service) http.Handler {
 // responses:
 //   '200':
 //    "$ref": "#/responses/listResponse"
+//   '204':
+//    description: No releases found
 //   '400':
 //    "$ref": "#/responses/listResponse"
 //   '404':

--- a/api/list/list.go
+++ b/api/list/list.go
@@ -63,7 +63,7 @@ type service interface {
 }
 
 // Handler handles a list request
-// swagger:operation GET /releases/{cluster} release listOperation
+// swagger:operation GET /clusters/{cluster}/releases release listOperation
 //
 //
 // ---
@@ -105,11 +105,11 @@ type service interface {
 //   '204':
 //    description: No releases found
 //   '400':
-//    "$ref": "#/responses/listResponse"
-//   '404':
-//    "$ref": "#/responses/listResponse"
+//    schema:
+//     $ref: "#/definitions/listErrorResponse"
 //   '500':
-//    "$ref": "#/responses/listResponse"
+//    schema:
+//     $ref: "#/definitions/listErrorResponse"
 func Handler(service service) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
@@ -141,7 +141,7 @@ func Handler(service service) http.Handler {
 }
 
 // Handler handles a list request
-// swagger:operation GET /releases/{cluster}/{namespace} release listOperationWithNamespace
+// swagger:operation GET /clusters/{cluster}/namespaces/{namespace}/releases release listOperationWithNamespace
 //
 //
 // ---

--- a/api/list/list.go
+++ b/api/list/list.go
@@ -63,15 +63,15 @@ type service interface {
 }
 
 // Handler handles a list request
-// swagger:operation GET /releases/{kube_context} release listOperation
+// swagger:operation GET /releases/{cluster} release listOperation
 //
-// List helm releases in the kubecontext as specified by query params
 //
 // ---
+// summary: List the helm release for the cluster
 // produces:
 // - application/json
 // parameters:
-// - name: kube_context
+// - name: cluster
 //   in: path
 //   required: true
 //   default: minikube
@@ -127,7 +127,7 @@ func Handler(service service) http.Handler {
 			return
 		}
 		values := mux.Vars(r)
-		req.KubeContext = values["kube_context"]
+		req.KubeContext = values["cluster"]
 		resp, err := service.List(r.Context(), req)
 		if err != nil {
 			respondListError(w, "error while listing charts: %v", err)

--- a/api/list/list_api_test.go
+++ b/api/list/list_api_test.go
@@ -46,8 +46,8 @@ func (s *ListTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
 	router := mux.NewRouter()
-	router.Handle("/releases/{cluster}", Handler(s.mockService)).Methods(http.MethodGet)
-	router.Handle("/releases/{cluster}/{namespace}", Handler(s.mockService)).Methods(http.MethodGet)
+	router.Handle("/clusters/{cluster}/releases", Handler(s.mockService)).Methods(http.MethodGet)
+	router.Handle("/clusters/{cluster}/namespaces/{namespace}/releases", Handler(s.mockService)).Methods(http.MethodGet)
 	s.server = httptest.NewServer(router)
 }
 
@@ -55,7 +55,7 @@ func (s *ListTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICall() {
 	layout := "2006-01-02T15:04:05.000Z"
 	str := "2014-11-12T11:45:26.371Z"
 	timeFromStr, _ := time.Parse(layout, str)
-	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/releases/staging?deployed=true", s.server.URL), nil)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/clusters/staging/releases?deployed=true", s.server.URL), nil)
 	expectedRequestStruct := Request{
 		Flags: Flags{
 			AllNamespaces: true,
@@ -100,7 +100,7 @@ func (s *ListTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICallNamespace()
 	layout := "2006-01-02T15:04:05.000Z"
 	str := "2014-11-12T11:45:26.371Z"
 	timeFromStr, _ := time.Parse(layout, str)
-	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/releases/staging/test?deployed=true", s.server.URL), nil)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/clusters/staging/namespaces/test/releases?deployed=true", s.server.URL), nil)
 	expectedRequestStruct := Request{
 		Flags: Flags{
 			Deployed: true,
@@ -142,7 +142,7 @@ func (s *ListTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICallNamespace()
 }
 
 func (s *ListTestSuite) TestShouldReturnNoContentWhenNoReleasesAreAvailable() {
-	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/releases/staging/test?deployed=true", s.server.URL), nil)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/clusters/staging/namespaces/test/releases?deployed=true", s.server.URL), nil)
 	expectedRequestStruct := Request{
 		Flags: Flags{
 			Deployed: true,
@@ -164,7 +164,7 @@ func (s *ListTestSuite) TestShouldReturnNoContentWhenNoReleasesAreAvailable() {
 	s.mockService.AssertExpectations(s.T())
 }
 func (s *ListTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidCharacter() {
-	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/releases/staging?deply=test", s.server.URL), nil)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/clusters/staging/releases?deply=test", s.server.URL), nil)
 
 	res, err := http.DefaultClient.Do(req)
 	require.NoError(s.T(), err)
@@ -174,7 +174,7 @@ func (s *ListTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidCharacter()
 }
 
 func (s *ListTestSuite) TestShouldReturnInternalServerErrorIfListServiceReturnsError() {
-	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/releases/staging/test?deployed=true", s.server.URL), nil)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/clusters/staging/namespaces/test/releases?deployed=true", s.server.URL), nil)
 	expectedRequestStruct := Request{
 		Flags: Flags{
 			Deployed: true,

--- a/api/list/list_api_test.go
+++ b/api/list/list_api_test.go
@@ -45,7 +45,7 @@ func (s *ListTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
 	router := mux.NewRouter()
-	router.Handle("/releases/{kube_context}", Handler(s.mockService)).Methods(http.MethodGet)
+	router.Handle("/releases/{cluster}", Handler(s.mockService)).Methods(http.MethodGet)
 	s.server = httptest.NewServer(router)
 }
 

--- a/api/list/list_api_test.go
+++ b/api/list/list_api_test.go
@@ -10,11 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gotest.tools/assert"
 
+	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 	"github.com/gojekfarm/albatross/pkg/logger"
 
 	"helm.sh/helm/v3/pkg/release"
@@ -31,9 +33,10 @@ func (m *mockService) List(ctx context.Context, req Request) (Response, error) {
 
 type ListTestSuite struct {
 	suite.Suite
-	recorder    *httptest.ResponseRecorder
-	server      *httptest.Server
-	mockService *mockService
+	recorder      *httptest.ResponseRecorder
+	server        *httptest.Server
+	mockService   *mockService
+	restfulServer *httptest.Server
 }
 
 func (s *ListTestSuite) SetupSuite() {
@@ -45,6 +48,9 @@ func (s *ListTestSuite) SetupTest() {
 	s.mockService = new(mockService)
 	handler := Handler(s.mockService)
 	s.server = httptest.NewServer(handler)
+	router := mux.NewRouter()
+	router.Handle("/releases/{kube_context}", RestHandler(s.mockService)).Methods(http.MethodGet)
+	s.restfulServer = httptest.NewServer(router)
 }
 
 func (s *ListTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICall() {
@@ -85,9 +91,65 @@ func (s *ListTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICall() {
 	s.mockService.AssertExpectations(s.T())
 }
 
+func (s *ListTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICallRestful() {
+	layout := "2006-01-02T15:04:05.000Z"
+	str := "2014-11-12T11:45:26.371Z"
+	timeFromStr, _ := time.Parse(layout, str)
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/releases/staging?all_namespaces=false&deployed=true&namespace=test", s.restfulServer.URL), nil)
+	expectedRequestStruct := Request{
+		Flags: Flags{
+			AllNamespaces: false,
+			Deployed:      true,
+			GlobalFlags: flags.GlobalFlags{
+				Namespace:   "test",
+				KubeContext: "staging",
+			},
+		},
+	}
+	response := Response{
+		Releases: []Release{
+			{
+				Name:       "test-release",
+				Namespace:  "test",
+				Version:    1,
+				Updated:    timeFromStr,
+				Status:     release.StatusDeployed,
+				AppVersion: "0.1",
+			},
+		},
+	}
+	s.mockService.On("List", mock.Anything, expectedRequestStruct).Return(response, nil)
+
+	res, err := http.DefaultClient.Do(req)
+	assert.Equal(s.T(), 200, res.StatusCode)
+	require.NoError(s.T(), err)
+
+	var actualResponse Response
+	err = json.NewDecoder(res.Body).Decode(&actualResponse)
+
+	expectedResponse := Response{
+		Error:    "",
+		Releases: response.Releases,
+	}
+
+	assert.Equal(s.T(), expectedResponse.Releases[0], actualResponse.Releases[0])
+	require.NoError(s.T(), err)
+	s.mockService.AssertExpectations(s.T())
+}
+
 func (s *ListTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidCharacter() {
 	body := `{"release_status":"unknown""""}`
 	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/list", s.server.URL), strings.NewReader(body))
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(s.T(), err)
+
+	assert.Equal(s.T(), 400, res.StatusCode)
+	require.NoError(s.T(), err)
+}
+
+func (s *ListTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidCharacterRestful() {
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/releases/staging?namespce=test", s.restfulServer.URL), nil)
 
 	res, err := http.DefaultClient.Do(req)
 	require.NoError(s.T(), err)

--- a/api/list/service.go
+++ b/api/list/service.go
@@ -16,7 +16,13 @@ type Service struct {
 
 func (s Service) List(ctx context.Context, req Request) (Response, error) {
 	listflags := flags.ListFlags{
-		GlobalFlags: req.Flags.GlobalFlags,
+		GlobalFlags:   req.Flags.GlobalFlags,
+		AllNamespaces: req.AllNamespaces,
+		Deployed:      req.Deployed,
+		Failed:        req.Failed,
+		Uninstalled:   req.Uninstalled,
+		Uninstalling:  req.Uninstalling,
+		Pending:       req.Pending,
 	}
 	lcli, err := s.cli.NewLister(listflags)
 	if err != nil {

--- a/api/list/service_test.go
+++ b/api/list/service_test.go
@@ -55,8 +55,18 @@ func TestShouldReturnValidResponseOnSuccess(t *testing.T) {
 	lic := new(mockLister)
 	service := NewService(cli)
 	ctx := context.Background()
-	req := Request{Flags: Flags{Deployed: true}}
-	cli.On("NewLister", mock.AnythingOfType("flags.ListFlags")).Return(lic, nil)
+	req := Request{Flags: Flags{Deployed: true, Uninstalled: true, Pending: true, GlobalFlags: flags.GlobalFlags{
+		KubeContext: "abc", Namespace: "test",
+	}}}
+	listFlags := flags.ListFlags{
+		Deployed:    true,
+		Uninstalled: true,
+		Pending:     true,
+		GlobalFlags: flags.GlobalFlags{
+			KubeContext: "abc", Namespace: "test",
+		},
+	}
+	cli.On("NewLister", listFlags).Return(lic, nil)
 	chartloader, err := loader.Loader("../testdata/albatross")
 	if err != nil {
 		panic("Could not load chart")

--- a/api/uninstall/uninstall.go
+++ b/api/uninstall/uninstall.go
@@ -69,15 +69,15 @@ type service interface {
 }
 
 // Handler handles an uninstall request
-// swagger:operation DELETE /releases/{kube_context}/{namespace}/{release_name} release uninstallOperation
+// swagger:operation DELETE /releases/{cluster}/{namespace}/{release_name} release uninstallOperation
 //
-// Uninstall a helm release as specified in the request
 //
 // ---
+// summary: Uninstall a helm release
 // produces:
 // - application/json
 // parameters:
-// - name: kube_context
+// - name: cluster
 //   in: path
 //   required: true
 //   default: minikube
@@ -135,7 +135,7 @@ func Handler(s service) http.Handler {
 		}
 		values := mux.Vars(r)
 		req.ReleaseName = values["release_name"]
-		req.GlobalFlags.KubeContext = values["kube_context"]
+		req.GlobalFlags.KubeContext = values["cluster"]
 		req.GlobalFlags.Namespace = values["namespace"]
 		if err := req.valid(); err != nil {
 			logger.Errorf("[Uninstall] error in request parameters: %v", err)

--- a/api/uninstall/uninstall.go
+++ b/api/uninstall/uninstall.go
@@ -69,7 +69,7 @@ type service interface {
 }
 
 // Handler handles an uninstall request
-// swagger:operation DELETE /releases/{cluster}/{namespace}/{release_name} release uninstallOperation
+// swagger:operation DELETE /clusters/{cluster}/namespaces/{namespace}/releases/{release_name} release uninstallOperation
 //
 //
 // ---
@@ -117,9 +117,11 @@ type service interface {
 //   '200':
 //    "$ref": "#/responses/uninstallResponse"
 //   '400':
-//    "$ref": "#/responses/uninstallResponse"
+//    schema:
+//     $ref: "#/definitions/uninstallErrorResponse"
 //   '404':
-//    "$ref": "#/responses/uninstallResponse"
+//    schema:
+//     $ref: "#/definitions/uninstallErrorResponse"
 //   '500':
 //    "$ref": "#/responses/uninstallResponse"
 func Handler(s service) http.Handler {

--- a/api/uninstall/uninstall_test.go
+++ b/api/uninstall/uninstall_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
@@ -33,10 +32,9 @@ func (m *mockService) Uninstall(ctx context.Context, req Request) (Response, err
 
 type UninstallTestSuite struct {
 	suite.Suite
-	recorder      *httptest.ResponseRecorder
-	server        *httptest.Server
-	restfulServer *httptest.Server
-	mockService   *mockService
+	recorder    *httptest.ResponseRecorder
+	server      *httptest.Server
+	mockService *mockService
 }
 
 func (s *UninstallTestSuite) SetupSuite() {
@@ -46,51 +44,13 @@ func (s *UninstallTestSuite) SetupSuite() {
 func (s *UninstallTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
-	handler := Handler(s.mockService)
-	s.server = httptest.NewServer(handler)
 	router := mux.NewRouter()
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", RestHandler(s.mockService)).Methods(http.MethodDelete)
-	s.restfulServer = httptest.NewServer(router)
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodDelete)
+	s.server = httptest.NewServer(router)
 }
 
 func (s *UninstallTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICall() {
-	body := fmt.Sprintf(`{"release_name":"%v", "timeout":2}`, testReleaseName)
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/uninstall", s.server.URL), strings.NewReader(body))
-	requestSturct := Request{
-		ReleaseName: testReleaseName,
-		Timeout:     2,
-	}
-	releaseOptions := &release.MockReleaseOptions{
-		Name:      testReleaseName,
-		Version:   1,
-		Namespace: "default",
-		Chart:     nil,
-		Status:    release.StatusDeployed,
-	}
-	mockRelease := releaseInfo(release.Mock(releaseOptions))
-	response := Response{
-		Release: mockRelease,
-	}
-	s.mockService.On("Uninstall", mock.Anything, requestSturct).Times(1).Return(response, nil)
-
-	res, err := http.DefaultClient.Do(req)
-
-	assert.Equal(s.T(), 200, res.StatusCode)
-	require.NoError(s.T(), err)
-
-	var actualResponse Response
-	err = json.NewDecoder(res.Body).Decode(&actualResponse)
-	assert.NilError(s.T(), err)
-	assert.Equal(s.T(), mockRelease.Name, actualResponse.Release.Name)
-	assert.Equal(s.T(), mockRelease.Version, actualResponse.Release.Version)
-	assert.Equal(s.T(), mockRelease.Namespace, actualResponse.Release.Namespace)
-	assert.Equal(s.T(), mockRelease.Status, actualResponse.Release.Status)
-	require.NoError(s.T(), err)
-	s.mockService.AssertExpectations(s.T())
-}
-
-func (s *UninstallTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICallRestful() {
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s?timeout=2", s.restfulServer.URL, testReleaseName), nil)
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s?timeout=2", s.server.URL, testReleaseName), nil)
 	requestSturct := Request{
 		ReleaseName: testReleaseName,
 		Timeout:     2,
@@ -128,9 +88,81 @@ func (s *UninstallTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICallRestfu
 	s.mockService.AssertExpectations(s.T())
 }
 
+func (s *UninstallTestSuite) TestShouldReturnNotFoundErrorIfItHasUnavailableReleaseName() {
+	unavailableReleaseName := "unknown_release"
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s", s.server.URL, unavailableReleaseName), nil)
+	requestStruct := Request{
+		ReleaseName: unavailableReleaseName,
+		GlobalFlags: flags.GlobalFlags{
+			KubeContext: "minikube",
+			Namespace:   "default",
+		},
+	}
+	s.mockService.On("Uninstall", mock.Anything, requestStruct).Times(1).Return(Response{}, driver.ErrReleaseNotFound)
+
+	res, err := http.DefaultClient.Do(req)
+
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 404, res.StatusCode)
+	require.NoError(s.T(), err)
+	s.mockService.AssertExpectations(s.T())
+}
+
+func (s *UninstallTestSuite) TestShouldReturnInternalServerErrorIfUninstallThrowsUnknownError() {
+	errMsg := "Test error Message"
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s", s.server.URL, testReleaseName), nil)
+	requestSturct := Request{
+		ReleaseName: testReleaseName,
+		GlobalFlags: flags.GlobalFlags{
+			KubeContext: "minikube",
+			Namespace:   "default",
+		},
+	}
+	releaseOptions := &release.MockReleaseOptions{
+		Name:      testReleaseName,
+		Version:   1,
+		Namespace: "default",
+		Chart:     nil,
+		Status:    release.StatusDeployed,
+	}
+	mockRelease := releaseInfo(release.Mock(releaseOptions))
+	response := Response{
+		Release: mockRelease,
+	}
+	s.mockService.On("Uninstall", mock.Anything, requestSturct).Times(1).Return(response, errors.New(errMsg))
+
+	res, err := http.DefaultClient.Do(req)
+
+	assert.Equal(s.T(), 500, res.StatusCode)
+	require.NoError(s.T(), err)
+
+	var actualResponse Response
+	err = json.NewDecoder(res.Body).Decode(&actualResponse)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), errMsg, actualResponse.Error)
+	s.mockService.AssertExpectations(s.T())
+}
+
+func (s *UninstallTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidReleaseName() {
+	invalidReleaseName := "a very long release name which is invalid plus some more gibberish"
+	req, _ := http.NewRequest("DELETE", fmt.Sprintf("%s/releases/minikube/default/%s", s.server.URL, invalidReleaseName), nil)
+
+	res, err := http.DefaultClient.Do(req)
+
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), res)
+	var actualResponse Response
+	err = json.NewDecoder(res.Body).Decode(&actualResponse)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), actualResponse.Error, errInvalidReleaseName.Error())
+	assert.Equal(s.T(), 400, res.StatusCode)
+	require.NoError(s.T(), err)
+	s.mockService.AssertExpectations(s.T())
+}
+
 func (s *UninstallTestSuite) TestAllQueryParam() {
 	req, _ := http.NewRequest(http.MethodDelete,
-		fmt.Sprintf("%s/releases/minikube/default/%s?timeout=2&dry_run=true&disable_hooks=true&keep_history=true", s.restfulServer.URL, testReleaseName),
+		fmt.Sprintf("%s/releases/minikube/default/%s?timeout=2&dry_run=true&disable_hooks=true&keep_history=true", s.server.URL, testReleaseName),
 		nil)
 	requestSturct := Request{
 		ReleaseName:  testReleaseName,
@@ -172,147 +204,8 @@ func (s *UninstallTestSuite) TestAllQueryParam() {
 	s.mockService.AssertExpectations(s.T())
 }
 
-func (s *UninstallTestSuite) TestShouldReturnNotFoundErrorIfItHasUnavailableReleaseName() {
-	unavailableReleaseName := "unknown_release"
-	body := fmt.Sprintf(`{"release_name":"%v"}`, unavailableReleaseName)
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/uninstall", s.server.URL), strings.NewReader(body))
-	requestStruct := Request{
-		ReleaseName: unavailableReleaseName,
-	}
-	s.mockService.On("Uninstall", mock.Anything, requestStruct).Times(1).Return(Response{}, driver.ErrReleaseNotFound)
-
-	res, err := http.DefaultClient.Do(req)
-
-	require.NoError(s.T(), err)
-	assert.Equal(s.T(), 404, res.StatusCode)
-	require.NoError(s.T(), err)
-	s.mockService.AssertExpectations(s.T())
-}
-
-func (s *UninstallTestSuite) TestShouldReturnNotFoundErrorIfItHasUnavailableReleaseNameRestful() {
-	unavailableReleaseName := "unknown_release"
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s", s.restfulServer.URL, unavailableReleaseName), nil)
-	requestStruct := Request{
-		ReleaseName: unavailableReleaseName,
-		GlobalFlags: flags.GlobalFlags{
-			KubeContext: "minikube",
-			Namespace:   "default",
-		},
-	}
-	s.mockService.On("Uninstall", mock.Anything, requestStruct).Times(1).Return(Response{}, driver.ErrReleaseNotFound)
-
-	res, err := http.DefaultClient.Do(req)
-
-	require.NoError(s.T(), err)
-	assert.Equal(s.T(), 404, res.StatusCode)
-	require.NoError(s.T(), err)
-	s.mockService.AssertExpectations(s.T())
-}
-
-func (s *UninstallTestSuite) TestShouldReturnInternalServerErrorIfUninstallThrowsUnknownError() {
-	body := fmt.Sprintf(`{"release_name":"%v"}`, testReleaseName)
-	errMsg := "Test error Message"
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/uninstall", s.server.URL), strings.NewReader(body))
-	requestSturct := Request{
-		ReleaseName: testReleaseName,
-	}
-	releaseOptions := &release.MockReleaseOptions{
-		Name:      testReleaseName,
-		Version:   1,
-		Namespace: "default",
-		Chart:     nil,
-		Status:    release.StatusDeployed,
-	}
-	mockRelease := releaseInfo(release.Mock(releaseOptions))
-	response := Response{
-		Release: mockRelease,
-	}
-	s.mockService.On("Uninstall", mock.Anything, requestSturct).Times(1).Return(response, errors.New(errMsg))
-
-	res, err := http.DefaultClient.Do(req)
-
-	assert.Equal(s.T(), 500, res.StatusCode)
-	require.NoError(s.T(), err)
-
-	var actualResponse Response
-	err = json.NewDecoder(res.Body).Decode(&actualResponse)
-	require.NoError(s.T(), err)
-	assert.Equal(s.T(), errMsg, actualResponse.Error)
-	s.mockService.AssertExpectations(s.T())
-}
-
-func (s *UninstallTestSuite) TestShouldReturnInternalServerErrorIfUninstallThrowsUnknownErrorRestful() {
-	errMsg := "Test error Message"
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s", s.restfulServer.URL, testReleaseName), nil)
-	requestSturct := Request{
-		ReleaseName: testReleaseName,
-		GlobalFlags: flags.GlobalFlags{
-			KubeContext: "minikube",
-			Namespace:   "default",
-		},
-	}
-	releaseOptions := &release.MockReleaseOptions{
-		Name:      testReleaseName,
-		Version:   1,
-		Namespace: "default",
-		Chart:     nil,
-		Status:    release.StatusDeployed,
-	}
-	mockRelease := releaseInfo(release.Mock(releaseOptions))
-	response := Response{
-		Release: mockRelease,
-	}
-	s.mockService.On("Uninstall", mock.Anything, requestSturct).Times(1).Return(response, errors.New(errMsg))
-
-	res, err := http.DefaultClient.Do(req)
-
-	assert.Equal(s.T(), 500, res.StatusCode)
-	require.NoError(s.T(), err)
-
-	var actualResponse Response
-	err = json.NewDecoder(res.Body).Decode(&actualResponse)
-	require.NoError(s.T(), err)
-	assert.Equal(s.T(), errMsg, actualResponse.Error)
-	s.mockService.AssertExpectations(s.T())
-}
-
-func (s *UninstallTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidReleaseName() {
-	body := `{"release_name":""}`
-	req, _ := http.NewRequest("DELETE", fmt.Sprintf("%s/uninstall", s.server.URL), strings.NewReader(body))
-
-	res, err := http.DefaultClient.Do(req)
-
-	require.NoError(s.T(), err)
-	require.NotNil(s.T(), res)
-	var actualResponse Response
-	err = json.NewDecoder(res.Body).Decode(&actualResponse)
-	require.NoError(s.T(), err)
-	assert.Equal(s.T(), actualResponse.Error, errInvalidReleaseName.Error())
-	assert.Equal(s.T(), 400, res.StatusCode)
-	require.NoError(s.T(), err)
-	s.mockService.AssertExpectations(s.T())
-}
-
-func (s *UninstallTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidReleaseNameRestful() {
-	invalidReleaseName := "a very long release name which is invalid plus some more gibberish"
-	req, _ := http.NewRequest("DELETE", fmt.Sprintf("%s/releases/minikube/default/%s", s.restfulServer.URL, invalidReleaseName), nil)
-
-	res, err := http.DefaultClient.Do(req)
-
-	require.NoError(s.T(), err)
-	require.NotNil(s.T(), res)
-	var actualResponse Response
-	err = json.NewDecoder(res.Body).Decode(&actualResponse)
-	require.NoError(s.T(), err)
-	assert.Equal(s.T(), actualResponse.Error, errInvalidReleaseName.Error())
-	assert.Equal(s.T(), 400, res.StatusCode)
-	require.NoError(s.T(), err)
-	s.mockService.AssertExpectations(s.T())
-}
-
 func (s *UninstallTestSuite) TearDownTest() {
 	s.server.Close()
-	s.restfulServer.Close()
 }
 
 func TestUninstallApi(t *testing.T) {

--- a/api/uninstall/uninstall_test.go
+++ b/api/uninstall/uninstall_test.go
@@ -10,14 +10,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
+	"github.com/gojekfarm/albatross/pkg/logger"
+
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gotest.tools/assert"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
-
-	"github.com/gojekfarm/albatross/pkg/logger"
 )
 
 type mockService struct {
@@ -31,9 +33,10 @@ func (m *mockService) Uninstall(ctx context.Context, req Request) (Response, err
 
 type UninstallTestSuite struct {
 	suite.Suite
-	recorder    *httptest.ResponseRecorder
-	server      *httptest.Server
-	mockService *mockService
+	recorder      *httptest.ResponseRecorder
+	server        *httptest.Server
+	restfulServer *httptest.Server
+	mockService   *mockService
 }
 
 func (s *UninstallTestSuite) SetupSuite() {
@@ -45,6 +48,9 @@ func (s *UninstallTestSuite) SetupTest() {
 	s.mockService = new(mockService)
 	handler := Handler(s.mockService)
 	s.server = httptest.NewServer(handler)
+	router := mux.NewRouter()
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", RestHandler(s.mockService)).Methods(http.MethodDelete)
+	s.restfulServer = httptest.NewServer(router)
 }
 
 func (s *UninstallTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICall() {
@@ -53,6 +59,89 @@ func (s *UninstallTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICall() {
 	requestSturct := Request{
 		ReleaseName: testReleaseName,
 		Timeout:     2,
+	}
+	releaseOptions := &release.MockReleaseOptions{
+		Name:      testReleaseName,
+		Version:   1,
+		Namespace: "default",
+		Chart:     nil,
+		Status:    release.StatusDeployed,
+	}
+	mockRelease := releaseInfo(release.Mock(releaseOptions))
+	response := Response{
+		Release: mockRelease,
+	}
+	s.mockService.On("Uninstall", mock.Anything, requestSturct).Times(1).Return(response, nil)
+
+	res, err := http.DefaultClient.Do(req)
+
+	assert.Equal(s.T(), 200, res.StatusCode)
+	require.NoError(s.T(), err)
+
+	var actualResponse Response
+	err = json.NewDecoder(res.Body).Decode(&actualResponse)
+	assert.NilError(s.T(), err)
+	assert.Equal(s.T(), mockRelease.Name, actualResponse.Release.Name)
+	assert.Equal(s.T(), mockRelease.Version, actualResponse.Release.Version)
+	assert.Equal(s.T(), mockRelease.Namespace, actualResponse.Release.Namespace)
+	assert.Equal(s.T(), mockRelease.Status, actualResponse.Release.Status)
+	require.NoError(s.T(), err)
+	s.mockService.AssertExpectations(s.T())
+}
+
+func (s *UninstallTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICallRestful() {
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s?timeout=2", s.restfulServer.URL, testReleaseName), nil)
+	requestSturct := Request{
+		ReleaseName: testReleaseName,
+		Timeout:     2,
+		GlobalFlags: flags.GlobalFlags{
+			KubeContext: "minikube",
+			Namespace:   "default",
+		},
+	}
+	releaseOptions := &release.MockReleaseOptions{
+		Name:      testReleaseName,
+		Version:   1,
+		Namespace: "default",
+		Chart:     nil,
+		Status:    release.StatusDeployed,
+	}
+	mockRelease := releaseInfo(release.Mock(releaseOptions))
+	response := Response{
+		Release: mockRelease,
+	}
+	s.mockService.On("Uninstall", mock.Anything, requestSturct).Times(1).Return(response, nil)
+
+	res, err := http.DefaultClient.Do(req)
+
+	assert.Equal(s.T(), 200, res.StatusCode)
+	require.NoError(s.T(), err)
+
+	var actualResponse Response
+	err = json.NewDecoder(res.Body).Decode(&actualResponse)
+	assert.NilError(s.T(), err)
+	assert.Equal(s.T(), mockRelease.Name, actualResponse.Release.Name)
+	assert.Equal(s.T(), mockRelease.Version, actualResponse.Release.Version)
+	assert.Equal(s.T(), mockRelease.Namespace, actualResponse.Release.Namespace)
+	assert.Equal(s.T(), mockRelease.Status, actualResponse.Release.Status)
+	require.NoError(s.T(), err)
+	s.mockService.AssertExpectations(s.T())
+}
+
+func (s *UninstallTestSuite) TestAllQueryParam() {
+	req, _ := http.NewRequest(http.MethodDelete,
+		fmt.Sprintf("%s/releases/minikube/default/%s?timeout=2&dry_run=true&disable_hooks=true&keep_history=true", s.restfulServer.URL, testReleaseName),
+		nil)
+	requestSturct := Request{
+		ReleaseName:  testReleaseName,
+		Timeout:      2,
+		DryRun:       true,
+		DisableHooks: true,
+		KeepHistory:  true,
+		GlobalFlags: flags.GlobalFlags{
+			KubeContext: "minikube",
+			Namespace:   "default",
+		},
 	}
 	releaseOptions := &release.MockReleaseOptions{
 		Name:      testReleaseName,
@@ -100,12 +189,67 @@ func (s *UninstallTestSuite) TestShouldReturnNotFoundErrorIfItHasUnavailableRele
 	s.mockService.AssertExpectations(s.T())
 }
 
+func (s *UninstallTestSuite) TestShouldReturnNotFoundErrorIfItHasUnavailableReleaseNameRestful() {
+	unavailableReleaseName := "unknown_release"
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s", s.restfulServer.URL, unavailableReleaseName), nil)
+	requestStruct := Request{
+		ReleaseName: unavailableReleaseName,
+		GlobalFlags: flags.GlobalFlags{
+			KubeContext: "minikube",
+			Namespace:   "default",
+		},
+	}
+	s.mockService.On("Uninstall", mock.Anything, requestStruct).Times(1).Return(Response{}, driver.ErrReleaseNotFound)
+
+	res, err := http.DefaultClient.Do(req)
+
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), 404, res.StatusCode)
+	require.NoError(s.T(), err)
+	s.mockService.AssertExpectations(s.T())
+}
+
 func (s *UninstallTestSuite) TestShouldReturnInternalServerErrorIfUninstallThrowsUnknownError() {
 	body := fmt.Sprintf(`{"release_name":"%v"}`, testReleaseName)
 	errMsg := "Test error Message"
 	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/uninstall", s.server.URL), strings.NewReader(body))
 	requestSturct := Request{
 		ReleaseName: testReleaseName,
+	}
+	releaseOptions := &release.MockReleaseOptions{
+		Name:      testReleaseName,
+		Version:   1,
+		Namespace: "default",
+		Chart:     nil,
+		Status:    release.StatusDeployed,
+	}
+	mockRelease := releaseInfo(release.Mock(releaseOptions))
+	response := Response{
+		Release: mockRelease,
+	}
+	s.mockService.On("Uninstall", mock.Anything, requestSturct).Times(1).Return(response, errors.New(errMsg))
+
+	res, err := http.DefaultClient.Do(req)
+
+	assert.Equal(s.T(), 500, res.StatusCode)
+	require.NoError(s.T(), err)
+
+	var actualResponse Response
+	err = json.NewDecoder(res.Body).Decode(&actualResponse)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), errMsg, actualResponse.Error)
+	s.mockService.AssertExpectations(s.T())
+}
+
+func (s *UninstallTestSuite) TestShouldReturnInternalServerErrorIfUninstallThrowsUnknownErrorRestful() {
+	errMsg := "Test error Message"
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s", s.restfulServer.URL, testReleaseName), nil)
+	requestSturct := Request{
+		ReleaseName: testReleaseName,
+		GlobalFlags: flags.GlobalFlags{
+			KubeContext: "minikube",
+			Namespace:   "default",
+		},
 	}
 	releaseOptions := &release.MockReleaseOptions{
 		Name:      testReleaseName,
@@ -149,8 +293,26 @@ func (s *UninstallTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidReleas
 	s.mockService.AssertExpectations(s.T())
 }
 
+func (s *UninstallTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidReleaseNameRestful() {
+	invalidReleaseName := "a very long release name which is invalid plus some more gibberish"
+	req, _ := http.NewRequest("DELETE", fmt.Sprintf("%s/releases/minikube/default/%s", s.restfulServer.URL, invalidReleaseName), nil)
+
+	res, err := http.DefaultClient.Do(req)
+
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), res)
+	var actualResponse Response
+	err = json.NewDecoder(res.Body).Decode(&actualResponse)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), actualResponse.Error, errInvalidReleaseName.Error())
+	assert.Equal(s.T(), 400, res.StatusCode)
+	require.NoError(s.T(), err)
+	s.mockService.AssertExpectations(s.T())
+}
+
 func (s *UninstallTestSuite) TearDownTest() {
 	s.server.Close()
+	s.restfulServer.Close()
 }
 
 func TestUninstallApi(t *testing.T) {

--- a/api/uninstall/uninstall_test.go
+++ b/api/uninstall/uninstall_test.go
@@ -45,12 +45,12 @@ func (s *UninstallTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
 	router := mux.NewRouter()
-	router.Handle("/releases/{cluster}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodDelete)
+	router.Handle("/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}", Handler(s.mockService)).Methods(http.MethodDelete)
 	s.server = httptest.NewServer(router)
 }
 
 func (s *UninstallTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICall() {
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s?timeout=2", s.server.URL, testReleaseName), nil)
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/clusters/minikube/namespaces/default/releases/%s?timeout=2", s.server.URL, testReleaseName), nil)
 	requestSturct := Request{
 		ReleaseName: testReleaseName,
 		Timeout:     2,
@@ -90,7 +90,7 @@ func (s *UninstallTestSuite) TestShouldReturnReleasesWhenSuccessfulAPICall() {
 
 func (s *UninstallTestSuite) TestShouldReturnNotFoundErrorIfItHasUnavailableReleaseName() {
 	unavailableReleaseName := "unknown_release"
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s", s.server.URL, unavailableReleaseName), nil)
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/clusters/minikube/namespaces/default/releases/%s", s.server.URL, unavailableReleaseName), nil)
 	requestStruct := Request{
 		ReleaseName: unavailableReleaseName,
 		GlobalFlags: flags.GlobalFlags{
@@ -110,7 +110,7 @@ func (s *UninstallTestSuite) TestShouldReturnNotFoundErrorIfItHasUnavailableRele
 
 func (s *UninstallTestSuite) TestShouldReturnInternalServerErrorIfUninstallThrowsUnknownError() {
 	errMsg := "Test error Message"
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/releases/minikube/default/%s", s.server.URL, testReleaseName), nil)
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/clusters/minikube/namespaces/default/releases/%s", s.server.URL, testReleaseName), nil)
 	requestSturct := Request{
 		ReleaseName: testReleaseName,
 		GlobalFlags: flags.GlobalFlags{
@@ -145,7 +145,7 @@ func (s *UninstallTestSuite) TestShouldReturnInternalServerErrorIfUninstallThrow
 
 func (s *UninstallTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidReleaseName() {
 	invalidReleaseName := "a very long release name which is invalid plus some more gibberish"
-	req, _ := http.NewRequest("DELETE", fmt.Sprintf("%s/releases/minikube/default/%s", s.server.URL, invalidReleaseName), nil)
+	req, _ := http.NewRequest("DELETE", fmt.Sprintf("%s/clusters/minikube/namespaces/default/releases/%s", s.server.URL, invalidReleaseName), nil)
 
 	res, err := http.DefaultClient.Do(req)
 
@@ -162,7 +162,7 @@ func (s *UninstallTestSuite) TestShouldReturnBadRequestErrorIfItHasInvalidReleas
 
 func (s *UninstallTestSuite) TestAllQueryParam() {
 	req, _ := http.NewRequest(http.MethodDelete,
-		fmt.Sprintf("%s/releases/minikube/default/%s?timeout=2&dry_run=true&disable_hooks=true&keep_history=true", s.server.URL, testReleaseName),
+		fmt.Sprintf("%s/clusters/minikube/namespaces/default/releases/%s?timeout=2&dry_run=true&disable_hooks=true&keep_history=true", s.server.URL, testReleaseName),
 		nil)
 	requestSturct := Request{
 		ReleaseName:  testReleaseName,

--- a/api/uninstall/uninstall_test.go
+++ b/api/uninstall/uninstall_test.go
@@ -45,7 +45,7 @@ func (s *UninstallTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
 	router := mux.NewRouter()
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodDelete)
+	router.Handle("/releases/{cluster}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodDelete)
 	s.server = httptest.NewServer(router)
 }
 

--- a/api/upgrade/upgrade.go
+++ b/api/upgrade/upgrade.go
@@ -111,13 +111,13 @@ type service interface {
 // - http
 // responses:
 //   '200':
-//    "$ref": "#/responses/listResponse"
+//    "$ref": "#/responses/upgradeResponse"
 //   '400':
-//    "$ref": "#/responses/listResponse"
+//    "$ref": "#/responses/upgradeResponse"
 //   '404':
-//    "$ref": "#/responses/listResponse"
+//    "$ref": "#/responses/upgradeResponse"
 //   '500':
-//    "$ref": "#/responses/listResponse"
+//    "$ref": "#/responses/upgradeResponse"
 func Handler(service service) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()

--- a/api/upgrade/upgrade.go
+++ b/api/upgrade/upgrade.go
@@ -74,7 +74,7 @@ type service interface {
 }
 
 // Handler handles an upgrade request
-// swagger:operation POST /releases/{cluster}/{namespace}/{release_name} release upgradeOperation
+// swagger:operation POST /clusters/{cluster}/namespaces/{namespace}/releases/{release_name} release upgradeOperation
 //
 //
 // ---
@@ -113,9 +113,7 @@ type service interface {
 //   '200':
 //    "$ref": "#/responses/upgradeResponse"
 //   '400':
-//    "$ref": "#/responses/upgradeResponse"
-//   '404':
-//    "$ref": "#/responses/upgradeResponse"
+//    description: "Invalid request"
 //   '500':
 //    "$ref": "#/responses/upgradeResponse"
 func Handler(service service) http.Handler {

--- a/api/upgrade/upgrade.go
+++ b/api/upgrade/upgrade.go
@@ -24,7 +24,7 @@ type Request struct {
 	// example: {"replicaCount": 1}
 	Values map[string]interface{} `json:"values"`
 	// Deprecated field
-	// example: {"kube_context": "minikube", "namespace":"default"}
+	// example: {"cluster": "minikube", "namespace":"default"}
 	Flags Flags `json:"flags"`
 }
 
@@ -74,17 +74,17 @@ type service interface {
 }
 
 // Handler handles an upgrade request
-// swagger:operation POST /releases/{kube_context}/{namespace}/{release_name} release upgradeOperation
+// swagger:operation POST /releases/{cluster}/{namespace}/{release_name} release upgradeOperation
 //
-// Install helm release at the specified location
 //
 // ---
+// summary: Upgrade a helm release deployed at the specified cluster and namespace
 // consumes:
 // - application/json
 // produces:
 // - application/json
 // parameters:
-// - name: kube_context
+// - name: cluster
 //   in: path
 //   required: true
 //   default: minikube
@@ -129,7 +129,7 @@ func Handler(service service) http.Handler {
 			return
 		}
 		values := mux.Vars(r)
-		req.Flags.KubeContext = values["kube_context"]
+		req.Flags.KubeContext = values["cluster"]
 		req.Flags.Namespace = values["namespace"]
 		req.Name = values["release_name"]
 		resp, err := service.Upgrade(r.Context(), req)

--- a/api/upgrade/upgrade_api_test.go
+++ b/api/upgrade/upgrade_api_test.go
@@ -9,11 +9,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gotest.tools/assert"
 
+	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 	"github.com/gojekfarm/albatross/pkg/logger"
 
 	"helm.sh/helm/v3/pkg/release"
@@ -30,9 +32,10 @@ func (m *mockService) Upgrade(ctx context.Context, req Request) (Response, error
 
 type UpgradeTestSuite struct {
 	suite.Suite
-	recorder    *httptest.ResponseRecorder
-	server      *httptest.Server
-	mockService *mockService
+	recorder       *httptest.ResponseRecorder
+	server         *httptest.Server
+	mockService    *mockService
+	restfultServer *httptest.Server
 }
 
 func (s *UpgradeTestSuite) SetupSuite() {
@@ -44,6 +47,9 @@ func (s *UpgradeTestSuite) SetupTest() {
 	s.mockService = new(mockService)
 	handler := Handler(s.mockService)
 	s.server = httptest.NewServer(handler)
+	router := mux.NewRouter()
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", RestHandler(s.mockService)).Methods(http.MethodPost)
+	s.restfultServer = httptest.NewServer(router)
 }
 
 func (s *UpgradeTestSuite) TestShouldReturnDeployedStatusOnSuccessfulUpgrade() {
@@ -72,6 +78,43 @@ func (s *UpgradeTestSuite) TestShouldReturnDeployedStatusOnSuccessfulUpgrade() {
 	s.mockService.AssertExpectations(s.T())
 }
 
+func (s *UpgradeTestSuite) TestShouldReturnDeployedStatusOnSuccessfulUpgradeRestful() {
+	chartName := "stable/redis-ha"
+	body := fmt.Sprintf(`{
+		"chart":"%s",
+		"flags": {
+			"install": true
+		},
+		"values": {
+			"usePassword": false
+		}}`, chartName)
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging/something/redis-v5", s.restfultServer.URL), strings.NewReader(body))
+	requestStruct := Request{
+		Name:  "redis-v5",
+		Chart: chartName,
+		Flags: Flags{
+			Install: true,
+			GlobalFlags: flags.GlobalFlags{
+				Namespace:   "something",
+				KubeContext: "staging",
+			},
+		},
+		Values: map[string]interface{}{
+			"usePassword": false,
+		},
+	}
+	response := Response{
+		Status: release.StatusDeployed.String(),
+	}
+	s.mockService.On("Upgrade", mock.Anything, requestStruct).Return(response, nil)
+
+	resp, err := http.DefaultClient.Do(req)
+
+	assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
+	require.NoError(s.T(), err)
+	s.mockService.AssertExpectations(s.T())
+}
+
 func (s *UpgradeTestSuite) TestShouldReturnInternalServerErrorOnFailure() {
 	chartName := "stable/redis-ha"
 	body := fmt.Sprintf(`{
@@ -89,6 +132,34 @@ func (s *UpgradeTestSuite) TestShouldReturnInternalServerErrorOnFailure() {
 	require.NoError(s.T(), err)
 }
 
+func (s *UpgradeTestSuite) TestShouldReturnInternalServerErrorOnFailureRestful() {
+	chartName := "stable/redis-ha"
+	body := fmt.Sprintf(`{
+    "chart":"%s",
+	"flags": {
+	    "install": true, "namespace": "something2", "version": "7.5.4"
+	}}`, chartName)
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging-context/something/redis-v5", s.restfultServer.URL), strings.NewReader(body))
+	requestStruct := Request{
+		Name:  "redis-v5",
+		Chart: chartName,
+		Flags: Flags{
+			Install: true,
+			Version: "7.5.4",
+			GlobalFlags: flags.GlobalFlags{
+				Namespace:   "something",
+				KubeContext: "staging-context",
+			},
+		},
+	}
+	s.mockService.On("Upgrade", mock.Anything, requestStruct).Return(Response{}, errors.New("invalid chart"))
+
+	resp, err := http.DefaultClient.Do(req)
+
+	assert.Equal(s.T(), http.StatusInternalServerError, resp.StatusCode)
+	require.NoError(s.T(), err)
+}
+
 func (s *UpgradeTestSuite) TestShouldBadRequestOnInvalidRequest() {
 	chartName := "stable/redis-ha"
 	body := fmt.Sprintf(`{
@@ -99,6 +170,22 @@ func (s *UpgradeTestSuite) TestShouldBadRequestOnInvalidRequest() {
 	}}`, chartName)
 	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/install", s.server.URL), strings.NewReader(body))
 	s.mockService.On("Upgrade", mock.Anything, mock.AnythingOfType("Request")).Return(Response{}, nil)
+
+	resp, err := http.DefaultClient.Do(req)
+
+	assert.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
+	require.NoError(s.T(), err)
+}
+
+func (s *UpgradeTestSuite) TestShouldBadRequestOnInvalidRequestRestful() {
+	chartName := "stable/redis-ha"
+	body := fmt.Sprintf(`{
+    "chart":"%s",
+	"name": "redis-v5",
+	"flags": {
+	    "install": true, "namespace": true, "version": 7.5.4
+	}}`, chartName)
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging-context/something/redis-v5", s.restfultServer.URL), strings.NewReader(body))
 
 	resp, err := http.DefaultClient.Do(req)
 

--- a/api/upgrade/upgrade_api_test.go
+++ b/api/upgrade/upgrade_api_test.go
@@ -32,10 +32,9 @@ func (m *mockService) Upgrade(ctx context.Context, req Request) (Response, error
 
 type UpgradeTestSuite struct {
 	suite.Suite
-	recorder       *httptest.ResponseRecorder
-	server         *httptest.Server
-	mockService    *mockService
-	restfultServer *httptest.Server
+	recorder    *httptest.ResponseRecorder
+	server      *httptest.Server
+	mockService *mockService
 }
 
 func (s *UpgradeTestSuite) SetupSuite() {
@@ -45,40 +44,12 @@ func (s *UpgradeTestSuite) SetupSuite() {
 func (s *UpgradeTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
-	handler := Handler(s.mockService)
-	s.server = httptest.NewServer(handler)
 	router := mux.NewRouter()
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", RestHandler(s.mockService)).Methods(http.MethodPost)
-	s.restfultServer = httptest.NewServer(router)
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodPost)
+	s.server = httptest.NewServer(router)
 }
 
 func (s *UpgradeTestSuite) TestShouldReturnDeployedStatusOnSuccessfulUpgrade() {
-	chartName := "stable/redis-ha"
-	body := fmt.Sprintf(`{
-		"chart":"%s",
-		"name": "redis-v5",
-		"flags": {
-			"install": false,
-			"namespace": "something"
-		},
-		"values": {
-			"usePassword": false
-		}}`, chartName)
-
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/upgrade", s.server.URL), strings.NewReader(body))
-	response := Response{
-		Status: release.StatusDeployed.String(),
-	}
-	s.mockService.On("Upgrade", mock.Anything, mock.AnythingOfType("Request")).Return(response, nil)
-
-	resp, err := http.DefaultClient.Do(req)
-
-	assert.Equal(s.T(), http.StatusOK, resp.StatusCode)
-	require.NoError(s.T(), err)
-	s.mockService.AssertExpectations(s.T())
-}
-
-func (s *UpgradeTestSuite) TestShouldReturnDeployedStatusOnSuccessfulUpgradeRestful() {
 	chartName := "stable/redis-ha"
 	body := fmt.Sprintf(`{
 		"chart":"%s",
@@ -88,7 +59,7 @@ func (s *UpgradeTestSuite) TestShouldReturnDeployedStatusOnSuccessfulUpgradeRest
 		"values": {
 			"usePassword": false
 		}}`, chartName)
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging/something/redis-v5", s.restfultServer.URL), strings.NewReader(body))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging/something/redis-v5", s.server.URL), strings.NewReader(body))
 	requestStruct := Request{
 		Name:  "redis-v5",
 		Chart: chartName,
@@ -119,27 +90,10 @@ func (s *UpgradeTestSuite) TestShouldReturnInternalServerErrorOnFailure() {
 	chartName := "stable/redis-ha"
 	body := fmt.Sprintf(`{
     "chart":"%s",
-	"name": "redis-v5",
-	"flags": {
-	    "install": true, "namespace": "something", "version": "7.5.4"
-	}}`, chartName)
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/install", s.server.URL), strings.NewReader(body))
-	s.mockService.On("Upgrade", mock.Anything, mock.AnythingOfType("Request")).Return(Response{}, errors.New("invalid chart"))
-
-	resp, err := http.DefaultClient.Do(req)
-
-	assert.Equal(s.T(), http.StatusInternalServerError, resp.StatusCode)
-	require.NoError(s.T(), err)
-}
-
-func (s *UpgradeTestSuite) TestShouldReturnInternalServerErrorOnFailureRestful() {
-	chartName := "stable/redis-ha"
-	body := fmt.Sprintf(`{
-    "chart":"%s",
 	"flags": {
 	    "install": true, "namespace": "something2", "version": "7.5.4"
 	}}`, chartName)
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging-context/something/redis-v5", s.restfultServer.URL), strings.NewReader(body))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging-context/something/redis-v5", s.server.URL), strings.NewReader(body))
 	requestStruct := Request{
 		Name:  "redis-v5",
 		Chart: chartName,
@@ -168,24 +122,7 @@ func (s *UpgradeTestSuite) TestShouldBadRequestOnInvalidRequest() {
 	"flags": {
 	    "install": true, "namespace": true, "version": 7.5.4
 	}}`, chartName)
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/install", s.server.URL), strings.NewReader(body))
-	s.mockService.On("Upgrade", mock.Anything, mock.AnythingOfType("Request")).Return(Response{}, nil)
-
-	resp, err := http.DefaultClient.Do(req)
-
-	assert.Equal(s.T(), http.StatusBadRequest, resp.StatusCode)
-	require.NoError(s.T(), err)
-}
-
-func (s *UpgradeTestSuite) TestShouldBadRequestOnInvalidRequestRestful() {
-	chartName := "stable/redis-ha"
-	body := fmt.Sprintf(`{
-    "chart":"%s",
-	"name": "redis-v5",
-	"flags": {
-	    "install": true, "namespace": true, "version": 7.5.4
-	}}`, chartName)
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging-context/something/redis-v5", s.restfultServer.URL), strings.NewReader(body))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging-context/something/redis-v5", s.server.URL), strings.NewReader(body))
 
 	resp, err := http.DefaultClient.Do(req)
 

--- a/api/upgrade/upgrade_api_test.go
+++ b/api/upgrade/upgrade_api_test.go
@@ -45,7 +45,7 @@ func (s *UpgradeTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
 	router := mux.NewRouter()
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodPost)
+	router.Handle("/releases/{cluster}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodPost)
 	s.server = httptest.NewServer(router)
 }
 

--- a/api/upgrade/upgrade_api_test.go
+++ b/api/upgrade/upgrade_api_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gotest.tools/assert"
 
 	"github.com/gojekfarm/albatross/pkg/helmcli/flags"
 	"github.com/gojekfarm/albatross/pkg/logger"
@@ -45,7 +45,7 @@ func (s *UpgradeTestSuite) SetupTest() {
 	s.recorder = httptest.NewRecorder()
 	s.mockService = new(mockService)
 	router := mux.NewRouter()
-	router.Handle("/releases/{cluster}/{namespace}/{release_name}", Handler(s.mockService)).Methods(http.MethodPost)
+	router.Handle("/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}", Handler(s.mockService)).Methods(http.MethodPost)
 	s.server = httptest.NewServer(router)
 }
 
@@ -59,7 +59,7 @@ func (s *UpgradeTestSuite) TestShouldReturnDeployedStatusOnSuccessfulUpgrade() {
 		"values": {
 			"usePassword": false
 		}}`, chartName)
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging/something/redis-v5", s.server.URL), strings.NewReader(body))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/clusters/staging/namespaces/something/releases/redis-v5", s.server.URL), strings.NewReader(body))
 	requestStruct := Request{
 		Name:  "redis-v5",
 		Chart: chartName,
@@ -93,7 +93,7 @@ func (s *UpgradeTestSuite) TestShouldReturnInternalServerErrorOnFailure() {
 	"flags": {
 	    "install": true, "namespace": "something2", "version": "7.5.4"
 	}}`, chartName)
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging-context/something/redis-v5", s.server.URL), strings.NewReader(body))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/clusters/staging-context/namespaces/something/releases/redis-v5", s.server.URL), strings.NewReader(body))
 	requestStruct := Request{
 		Name:  "redis-v5",
 		Chart: chartName,
@@ -122,7 +122,7 @@ func (s *UpgradeTestSuite) TestShouldBadRequestOnInvalidRequest() {
 	"flags": {
 	    "install": true, "namespace": true, "version": 7.5.4
 	}}`, chartName)
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/releases/staging-context/something/redis-v5", s.server.URL), strings.NewReader(body))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/clusters/staging-context/namespaces/something/releases/redis-v5", s.server.URL), strings.NewReader(body))
 
 	resp, err := http.DefaultClient.Do(req)
 

--- a/cmd/albatross/albatross.go
+++ b/cmd/albatross/albatross.go
@@ -36,31 +36,16 @@ func startServer() {
 	logger.Setup("debug")
 	cli := helmcli.New()
 
-	uninstallService := uninstall.NewService(cli)
-	listService := list.NewService(cli)
-	installService := install.NewService(cli)
-	upgradeService := upgrade.NewService(cli)
-
 	installHandler := install.Handler(install.NewService(cli))
 	upgradeHandler := upgrade.Handler(upgrade.NewService(cli))
-	listHandler := list.Handler(listService)
-	uninstallHandler := uninstall.Handler(uninstallService)
+	listHandler := list.Handler(list.NewService(cli))
+	uninstallHandler := uninstall.Handler(uninstall.NewService(cli))
 
 	router.Handle("/ping", ContentTypeMiddle(api.Ping())).Methods(http.MethodGet)
-	router.Handle("/list", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
-	router.Handle("/uninstall", ContentTypeMiddle(uninstallHandler)).Methods(http.MethodDelete)
-	router.Handle("/install", ContentTypeMiddle(installHandler)).Methods(http.MethodPut)
-	router.Handle("/upgrade", ContentTypeMiddle(upgradeHandler)).Methods(http.MethodPost)
-
-	restfulUninstallHandler := uninstall.RestHandler(uninstallService)
-	restfulListHandler := list.RestHandler(listService)
-	restfulInstallHandler := install.RestHandler(installService)
-	restfulUpgradeHandler := upgrade.RestHandler(upgradeService)
-
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(restfulUninstallHandler)).Methods(http.MethodDelete)
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(restfulInstallHandler)).Methods(http.MethodPut)
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(restfulUpgradeHandler)).Methods(http.MethodPost)
-	router.Handle("/releases/{kube_context}", ContentTypeMiddle(restfulListHandler)).Methods(http.MethodGet)
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(uninstallHandler)).Methods(http.MethodDelete)
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(installHandler)).Methods(http.MethodPut)
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(upgradeHandler)).Methods(http.MethodPost)
+	router.Handle("/releases/{kube_context}", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
 
 	serveDocumentation(router)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", 8080), router)

--- a/cmd/albatross/albatross.go
+++ b/cmd/albatross/albatross.go
@@ -42,10 +42,10 @@ func startServer() {
 	uninstallHandler := uninstall.Handler(uninstall.NewService(cli))
 
 	router.Handle("/ping", ContentTypeMiddle(api.Ping())).Methods(http.MethodGet)
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(uninstallHandler)).Methods(http.MethodDelete)
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(installHandler)).Methods(http.MethodPut)
-	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(upgradeHandler)).Methods(http.MethodPost)
-	router.Handle("/releases/{kube_context}", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
+	router.Handle("/releases/{cluster}/{namespace}/{release_name}", ContentTypeMiddle(uninstallHandler)).Methods(http.MethodDelete)
+	router.Handle("/releases/{cluster}/{namespace}/{release_name}", ContentTypeMiddle(installHandler)).Methods(http.MethodPut)
+	router.Handle("/releases/{cluster}/{namespace}/{release_name}", ContentTypeMiddle(upgradeHandler)).Methods(http.MethodPost)
+	router.Handle("/releases/{cluster}", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
 
 	serveDocumentation(router)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", 8080), router)

--- a/cmd/albatross/albatross.go
+++ b/cmd/albatross/albatross.go
@@ -36,16 +36,31 @@ func startServer() {
 	logger.Setup("debug")
 	cli := helmcli.New()
 
+	uninstallService := uninstall.NewService(cli)
+	listService := list.NewService(cli)
+	installService := install.NewService(cli)
+	upgradeService := upgrade.NewService(cli)
+
 	installHandler := install.Handler(install.NewService(cli))
 	upgradeHandler := upgrade.Handler(upgrade.NewService(cli))
-	listHandler := list.Handler(list.NewService(cli))
-	uninstallHandler := uninstall.Handler(uninstall.NewService(cli))
+	listHandler := list.Handler(listService)
+	uninstallHandler := uninstall.Handler(uninstallService)
 
 	router.Handle("/ping", ContentTypeMiddle(api.Ping())).Methods(http.MethodGet)
 	router.Handle("/list", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
 	router.Handle("/uninstall", ContentTypeMiddle(uninstallHandler)).Methods(http.MethodDelete)
 	router.Handle("/install", ContentTypeMiddle(installHandler)).Methods(http.MethodPut)
 	router.Handle("/upgrade", ContentTypeMiddle(upgradeHandler)).Methods(http.MethodPost)
+
+	restfulUninstallHandler := uninstall.RestHandler(uninstallService)
+	restfulListHandler := list.RestHandler(listService)
+	restfulInstallHandler := install.RestHandler(installService)
+	restfulUpgradeHandler := upgrade.RestHandler(upgradeService)
+
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(restfulUninstallHandler)).Methods(http.MethodDelete)
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(restfulInstallHandler)).Methods(http.MethodPut)
+	router.Handle("/releases/{kube_context}/{namespace}/{release_name}", ContentTypeMiddle(restfulUpgradeHandler)).Methods(http.MethodPost)
+	router.Handle("/releases/{kube_context}", ContentTypeMiddle(restfulListHandler)).Methods(http.MethodGet)
 
 	serveDocumentation(router)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", 8080), router)

--- a/cmd/albatross/albatross.go
+++ b/cmd/albatross/albatross.go
@@ -46,6 +46,7 @@ func startServer() {
 	router.Handle("/releases/{cluster}/{namespace}/{release_name}", ContentTypeMiddle(installHandler)).Methods(http.MethodPut)
 	router.Handle("/releases/{cluster}/{namespace}/{release_name}", ContentTypeMiddle(upgradeHandler)).Methods(http.MethodPost)
 	router.Handle("/releases/{cluster}", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
+	router.Handle("/releases/{cluster}/{namespace}", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
 
 	serveDocumentation(router)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", 8080), router)

--- a/cmd/albatross/albatross.go
+++ b/cmd/albatross/albatross.go
@@ -42,11 +42,11 @@ func startServer() {
 	uninstallHandler := uninstall.Handler(uninstall.NewService(cli))
 
 	router.Handle("/ping", ContentTypeMiddle(api.Ping())).Methods(http.MethodGet)
-	router.Handle("/releases/{cluster}/{namespace}/{release_name}", ContentTypeMiddle(uninstallHandler)).Methods(http.MethodDelete)
-	router.Handle("/releases/{cluster}/{namespace}/{release_name}", ContentTypeMiddle(installHandler)).Methods(http.MethodPut)
-	router.Handle("/releases/{cluster}/{namespace}/{release_name}", ContentTypeMiddle(upgradeHandler)).Methods(http.MethodPost)
-	router.Handle("/releases/{cluster}", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
-	router.Handle("/releases/{cluster}/{namespace}", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
+	router.Handle("/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}", ContentTypeMiddle(uninstallHandler)).Methods(http.MethodDelete)
+	router.Handle("/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}", ContentTypeMiddle(installHandler)).Methods(http.MethodPut)
+	router.Handle("/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}", ContentTypeMiddle(upgradeHandler)).Methods(http.MethodPost)
+	router.Handle("/clusters/{cluster}/releases", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
+	router.Handle("/clusters/{cluster}/namespaces/{namespace}/releases", ContentTypeMiddle(listHandler)).Methods(http.MethodGet)
 
 	serveDocumentation(router)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", 8080), router)

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -27,8 +27,77 @@
         "tags": [
           "release"
         ],
-        "summary": "List the helm release for the cluster",
+        "summary": "List the helm releases for the cluster",
         "operationId": "listOperation",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "string",
+            "default": "minikube",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "deployed",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "uninstalled",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "failed",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "pending",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "uninstalling",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/listResponse"
+          },
+          "400": {
+            "$ref": "#/responses/listResponse"
+          },
+          "404": {
+            "$ref": "#/responses/listResponse"
+          },
+          "500": {
+            "$ref": "#/responses/listResponse"
+          }
+        }
+      }
+    },
+    "/releases/{cluster}/{namespace}": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http"
+        ],
+        "tags": [
+          "release"
+        ],
+        "summary": "List the helm releases for the cluster and namespace",
+        "operationId": "listOperationWithNamespace",
         "parameters": [
           {
             "type": "string",
@@ -41,14 +110,10 @@
           {
             "type": "string",
             "format": "string",
+            "default": "default",
             "name": "namespace",
-            "in": "query"
-          },
-          {
-            "type": "boolean",
-            "default": true,
-            "name": "all_namespaces",
-            "in": "query"
+            "in": "path",
+            "required": true
           },
           {
             "type": "boolean",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16,9 +16,8 @@
   },
   "host": "localhost:8080",
   "paths": {
-    "/releases/{kube_context}": {
+    "/releases/{cluster}": {
       "get": {
-        "description": "List helm releases in the kubecontext as specified by query params",
         "produces": [
           "application/json"
         ],
@@ -28,13 +27,14 @@
         "tags": [
           "release"
         ],
+        "summary": "List the helm release for the cluster",
         "operationId": "listOperation",
         "parameters": [
           {
             "type": "string",
             "format": "string",
             "default": "minikube",
-            "name": "kube_context",
+            "name": "cluster",
             "in": "path",
             "required": true
           },
@@ -97,9 +97,8 @@
         }
       }
     },
-    "/releases/{kube_context}/{namespace}/{release_name}": {
+    "/releases/{cluster}/{namespace}/{release_name}": {
       "put": {
-        "description": "Install helm release at the specified location",
         "consumes": [
           "application/json"
         ],
@@ -112,13 +111,14 @@
         "tags": [
           "release"
         ],
+        "summary": "Install helm release at the specified cluster and namespace",
         "operationId": "installOperation",
         "parameters": [
           {
             "type": "string",
             "format": "string",
             "default": "minikube",
-            "name": "kube_context",
+            "name": "cluster",
             "in": "path",
             "required": true
           },
@@ -163,7 +163,6 @@
         }
       },
       "post": {
-        "description": "Install helm release at the specified location",
         "consumes": [
           "application/json"
         ],
@@ -176,13 +175,14 @@
         "tags": [
           "release"
         ],
+        "summary": "Upgrade a helm release deployed at the specified cluster and namespace",
         "operationId": "upgradeOperation",
         "parameters": [
           {
             "type": "string",
             "format": "string",
             "default": "minikube",
-            "name": "kube_context",
+            "name": "cluster",
             "in": "path",
             "required": true
           },
@@ -227,7 +227,6 @@
         }
       },
       "delete": {
-        "description": "Uninstall a helm release as specified in the request",
         "produces": [
           "application/json"
         ],
@@ -237,13 +236,14 @@
         "tags": [
           "release"
         ],
+        "summary": "Uninstall a helm release",
         "operationId": "uninstallOperation",
         "parameters": [
           {
             "type": "string",
             "format": "string",
             "default": "minikube",
-            "name": "kube_context",
+            "name": "cluster",
             "in": "path",
             "required": true
           },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16,79 +16,7 @@
   },
   "host": "localhost:8080",
   "paths": {
-    "/releases/{cluster}": {
-      "get": {
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http"
-        ],
-        "tags": [
-          "release"
-        ],
-        "summary": "List the helm releases for the cluster",
-        "operationId": "listOperation",
-        "parameters": [
-          {
-            "type": "string",
-            "format": "string",
-            "default": "minikube",
-            "name": "cluster",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "boolean",
-            "default": false,
-            "name": "deployed",
-            "in": "query"
-          },
-          {
-            "type": "boolean",
-            "default": false,
-            "name": "uninstalled",
-            "in": "query"
-          },
-          {
-            "type": "boolean",
-            "default": false,
-            "name": "failed",
-            "in": "query"
-          },
-          {
-            "type": "boolean",
-            "default": false,
-            "name": "pending",
-            "in": "query"
-          },
-          {
-            "type": "boolean",
-            "default": false,
-            "name": "uninstalling",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/listResponse"
-          },
-          "204": {
-            "description": "No releases found"
-          },
-          "400": {
-            "$ref": "#/responses/listResponse"
-          },
-          "404": {
-            "$ref": "#/responses/listResponse"
-          },
-          "500": {
-            "$ref": "#/responses/listResponse"
-          }
-        }
-      }
-    },
-    "/releases/{cluster}/{namespace}": {
+    "/clusters/{cluster}/namespaces/{namespace}/releases": {
       "get": {
         "produces": [
           "application/json"
@@ -168,7 +96,7 @@
         }
       }
     },
-    "/releases/{cluster}/{namespace}/{release_name}": {
+    "/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}": {
       "put": {
         "consumes": [
           "application/json"
@@ -223,10 +151,13 @@
             "$ref": "#/responses/installResponse"
           },
           "400": {
-            "$ref": "#/responses/installResponse"
+            "description": "Invalid request"
           },
-          "404": {
-            "$ref": "#/responses/installResponse"
+          "409": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/installResponseErrorBody"
+            }
           },
           "500": {
             "$ref": "#/responses/installResponse"
@@ -287,10 +218,7 @@
             "$ref": "#/responses/upgradeResponse"
           },
           "400": {
-            "$ref": "#/responses/upgradeResponse"
-          },
-          "404": {
-            "$ref": "#/responses/upgradeResponse"
+            "description": "Invalid request"
           },
           "500": {
             "$ref": "#/responses/upgradeResponse"
@@ -364,13 +292,94 @@
             "$ref": "#/responses/uninstallResponse"
           },
           "400": {
-            "$ref": "#/responses/uninstallResponse"
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/uninstallErrorResponse"
+            }
           },
           "404": {
-            "$ref": "#/responses/uninstallResponse"
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/uninstallErrorResponse"
+            }
           },
           "500": {
             "$ref": "#/responses/uninstallResponse"
+          }
+        }
+      }
+    },
+    "/clusters/{cluster}/releases": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http"
+        ],
+        "tags": [
+          "release"
+        ],
+        "summary": "List the helm releases for the cluster",
+        "operationId": "listOperation",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "string",
+            "default": "minikube",
+            "name": "cluster",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "deployed",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "uninstalled",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "failed",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "pending",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "uninstalling",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/listResponse"
+          },
+          "204": {
+            "description": "No releases found"
+          },
+          "400": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/listErrorResponse"
+            }
+          },
+          "500": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/listErrorResponse"
+            }
           }
         }
       }
@@ -562,6 +571,29 @@
       "x-go-name": "Response",
       "x-go-package": "github.com/gojekfarm/albatross/api/install"
     },
+    "installResponseErrorBody": {
+      "description": "InstallErrorResponse body of install response",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string",
+          "x-go-name": "Error"
+        }
+      },
+      "x-go-name": "InstallErrorResponse",
+      "x-go-package": "github.com/gojekfarm/albatross/swagger"
+    },
+    "listErrorResponse": {
+      "description": "ListErrorResponse stub for swagger route for List",
+      "type": "object",
+      "properties": {
+        "Body": {
+          "$ref": "#/definitions/listReponseBody"
+        }
+      },
+      "x-go-name": "ListErrorResponse",
+      "x-go-package": "github.com/gojekfarm/albatross/swagger"
+    },
     "listRelease": {
       "description": "Release wraps a helm release",
       "type": "object",
@@ -623,6 +655,18 @@
       },
       "x-go-name": "Response",
       "x-go-package": "github.com/gojekfarm/albatross/api/list"
+    },
+    "uninstallErrorResponse": {
+      "description": "UninstallErrorResponse error body for uninstall action",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string",
+          "x-go-name": "Error"
+        }
+      },
+      "x-go-name": "UninstallErrorResponse",
+      "x-go-package": "github.com/gojekfarm/albatross/swagger"
     },
     "uninstallRelease": {
       "description": "Release contains metadata about a helm release object",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -73,6 +73,9 @@
           "200": {
             "$ref": "#/responses/listResponse"
           },
+          "204": {
+            "description": "No releases found"
+          },
           "400": {
             "$ref": "#/responses/listResponse"
           },
@@ -149,6 +152,9 @@
         "responses": {
           "200": {
             "$ref": "#/responses/listResponse"
+          },
+          "204": {
+            "description": "No releases found"
           },
           "400": {
             "$ref": "#/responses/listResponse"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -29,6 +29,7 @@
           "http"
         ],
         "operationId": "installRelease",
+        "deprecated": true,
         "parameters": [
           {
             "name": "Body",
@@ -64,6 +65,7 @@
           "http"
         ],
         "operationId": "listRelease",
+        "deprecated": true,
         "parameters": [
           {
             "name": "Body",
@@ -86,6 +88,285 @@
         }
       }
     },
+    "/releases/{kube_context}": {
+      "get": {
+        "description": "List helm releases in the kubecontext as specified by query params",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http"
+        ],
+        "tags": [
+          "release"
+        ],
+        "operationId": "listOperation",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "string",
+            "default": "minikube",
+            "name": "kube_context",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "string",
+            "name": "namespace",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": true,
+            "name": "all_namespaces",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "deployed",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "uninstalled",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "failed",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "pending",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "uninstalling",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/listResponse"
+          },
+          "400": {
+            "$ref": "#/responses/listResponse"
+          },
+          "404": {
+            "$ref": "#/responses/listResponse"
+          },
+          "500": {
+            "$ref": "#/responses/listResponse"
+          }
+        }
+      }
+    },
+    "/releases/{kube_context}/{namespace}/{release_name}": {
+      "put": {
+        "description": "Install helm release at the specified location",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http"
+        ],
+        "tags": [
+          "release"
+        ],
+        "operationId": "installOperation",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "string",
+            "default": "minikube",
+            "name": "kube_context",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "string",
+            "default": "default",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "string",
+            "name": "release_name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/installRequestBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/listResponse"
+          },
+          "400": {
+            "$ref": "#/responses/listResponse"
+          },
+          "404": {
+            "$ref": "#/responses/listResponse"
+          },
+          "500": {
+            "$ref": "#/responses/listResponse"
+          }
+        }
+      },
+      "post": {
+        "description": "Install helm release at the specified location",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http"
+        ],
+        "tags": [
+          "release"
+        ],
+        "operationId": "upgradeOperation",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "string",
+            "default": "minikube",
+            "name": "kube_context",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "string",
+            "default": "default",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "string",
+            "name": "release_name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/upgradeRequestBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/listResponse"
+          },
+          "400": {
+            "$ref": "#/responses/listResponse"
+          },
+          "404": {
+            "$ref": "#/responses/listResponse"
+          },
+          "500": {
+            "$ref": "#/responses/listResponse"
+          }
+        }
+      },
+      "delete": {
+        "description": "Uninstall a helm release as specified in the request",
+        "produces": [
+          "application/json"
+        ],
+        "schemes": [
+          "http"
+        ],
+        "tags": [
+          "release"
+        ],
+        "operationId": "uninstallOperation",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "string",
+            "default": "minikube",
+            "name": "kube_context",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "string",
+            "default": "default",
+            "name": "namespace",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "format": "string",
+            "name": "release_name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "dry_run",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "keep_history",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "disable_hooks",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "default": 300,
+            "name": "timeout",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/uninstallResponse"
+          },
+          "400": {
+            "$ref": "#/responses/uninstallResponse"
+          },
+          "404": {
+            "$ref": "#/responses/uninstallResponse"
+          },
+          "500": {
+            "$ref": "#/responses/uninstallResponse"
+          }
+        }
+      }
+    },
     "/uninstall": {
       "delete": {
         "description": "Uninstall a helm release as specified in the request",
@@ -99,6 +380,7 @@
           "http"
         ],
         "operationId": "uninstallRelease",
+        "deprecated": true,
         "parameters": [
           {
             "name": "Body",
@@ -134,6 +416,7 @@
           "http"
         ],
         "operationId": "upgradeRelease",
+        "deprecated": true,
         "parameters": [
           {
             "name": "Body",
@@ -302,6 +585,7 @@
           "$ref": "#/definitions/installFlags"
         },
         "name": {
+          "description": "Name not required when using resourceful API",
           "type": "string",
           "x-go-name": "Name",
           "example": "mysql"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -284,16 +284,16 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/listResponse"
+            "$ref": "#/responses/upgradeResponse"
           },
           "400": {
-            "$ref": "#/responses/listResponse"
+            "$ref": "#/responses/upgradeResponse"
           },
           "404": {
-            "$ref": "#/responses/listResponse"
+            "$ref": "#/responses/upgradeResponse"
           },
           "500": {
-            "$ref": "#/responses/listResponse"
+            "$ref": "#/responses/upgradeResponse"
           }
         }
       },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -16,78 +16,6 @@
   },
   "host": "localhost:8080",
   "paths": {
-    "/install": {
-      "put": {
-        "description": "Installs a helm release as specified in the request",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http"
-        ],
-        "operationId": "installRelease",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/installRequestBody"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/installResponse"
-          },
-          "400": {
-            "$ref": "#/responses/installResponse"
-          },
-          "500": {
-            "$ref": "#/responses/installResponse"
-          }
-        }
-      }
-    },
-    "/list": {
-      "get": {
-        "description": "List helm releases as specified in the request",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http"
-        ],
-        "operationId": "listRelease",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/listRequestBody"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/listResponse"
-          },
-          "400": {
-            "$ref": "#/responses/listResponse"
-          },
-          "500": {
-            "$ref": "#/responses/listResponse"
-          }
-        }
-      }
-    },
     "/releases/{kube_context}": {
       "get": {
         "description": "List helm releases in the kubecontext as specified by query params",
@@ -172,6 +100,9 @@
     "/releases/{kube_context}/{namespace}/{release_name}": {
       "put": {
         "description": "Install helm release at the specified location",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/json"
         ],
@@ -202,6 +133,7 @@
           {
             "type": "string",
             "format": "string",
+            "default": "mysql-final",
             "name": "release_name",
             "in": "path",
             "required": true
@@ -217,21 +149,24 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/listResponse"
+            "$ref": "#/responses/installResponse"
           },
           "400": {
-            "$ref": "#/responses/listResponse"
+            "$ref": "#/responses/installResponse"
           },
           "404": {
-            "$ref": "#/responses/listResponse"
+            "$ref": "#/responses/installResponse"
           },
           "500": {
-            "$ref": "#/responses/listResponse"
+            "$ref": "#/responses/installResponse"
           }
         }
       },
       "post": {
         "description": "Install helm release at the specified location",
+        "consumes": [
+          "application/json"
+        ],
         "produces": [
           "application/json"
         ],
@@ -262,6 +197,7 @@
           {
             "type": "string",
             "format": "string",
+            "default": "mysql-final",
             "name": "release_name",
             "in": "path",
             "required": true
@@ -322,6 +258,7 @@
           {
             "type": "string",
             "format": "string",
+            "default": "mysql-final",
             "name": "release_name",
             "in": "path",
             "required": true
@@ -366,81 +303,41 @@
           }
         }
       }
-    },
-    "/uninstall": {
-      "delete": {
-        "description": "Uninstall a helm release as specified in the request",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http"
-        ],
-        "operationId": "uninstallRelease",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/uninstallRequestBody"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/uninstallResponse"
-          },
-          "400": {
-            "$ref": "#/responses/uninstallResponse"
-          },
-          "500": {
-            "$ref": "#/responses/uninstallResponse"
-          }
-        }
-      }
-    },
-    "/upgrade": {
-      "post": {
-        "description": "Upgrades a helm release as specified in the request",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "schemes": [
-          "http"
-        ],
-        "operationId": "upgradeRelease",
-        "deprecated": true,
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/upgradeRequestBody"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "$ref": "#/responses/upgradeResponse"
-          },
-          "400": {
-            "$ref": "#/responses/upgradeResponse"
-          },
-          "500": {
-            "$ref": "#/responses/upgradeResponse"
-          }
-        }
-      }
     }
   },
   "definitions": {
+    "Request": {
+      "type": "object",
+      "properties": {
+        "AllNamespaces": {
+          "type": "boolean"
+        },
+        "Deployed": {
+          "type": "boolean"
+        },
+        "Failed": {
+          "type": "boolean"
+        },
+        "Pending": {
+          "type": "boolean"
+        },
+        "Uninstalled": {
+          "type": "boolean"
+        },
+        "Uninstalling": {
+          "type": "boolean"
+        },
+        "kube_apiserver": {
+          "type": "string",
+          "x-go-name": "KubeAPIServer"
+        },
+        "kube_token": {
+          "type": "string",
+          "x-go-name": "KubeToken"
+        }
+      },
+      "x-go-package": "github.com/gojekfarm/albatross/api/list"
+    },
     "Response": {
       "type": "object",
       "title": "Response represents the api response for upgrade request.",
@@ -465,27 +362,14 @@
     "globalFlags": {
       "description": "GlobalFlags flags which give context about kubernetes cluster to connect to",
       "type": "object",
-      "required": [
-        "namespace"
-      ],
       "properties": {
         "kube_apiserver": {
           "type": "string",
           "x-go-name": "KubeAPIServer"
         },
-        "kube_context": {
-          "type": "string",
-          "x-go-name": "KubeContext",
-          "example": "minikube"
-        },
         "kube_token": {
           "type": "string",
           "x-go-name": "KubeToken"
-        },
-        "namespace": {
-          "type": "string",
-          "x-go-name": "Namespace",
-          "example": "default"
         }
       },
       "x-go-name": "GlobalFlags",
@@ -494,9 +378,6 @@
     "installFlags": {
       "description": "Flags additional flags for installing a release",
       "type": "object",
-      "required": [
-        "namespace"
-      ],
       "properties": {
         "dry_run": {
           "type": "boolean",
@@ -507,19 +388,9 @@
           "type": "string",
           "x-go-name": "KubeAPIServer"
         },
-        "kube_context": {
-          "type": "string",
-          "x-go-name": "KubeContext",
-          "example": "minikube"
-        },
         "kube_token": {
           "type": "string",
           "x-go-name": "KubeToken"
-        },
-        "namespace": {
-          "type": "string",
-          "x-go-name": "Namespace",
-          "example": "default"
         },
         "version": {
           "type": "string",
@@ -583,12 +454,6 @@
         },
         "flags": {
           "$ref": "#/definitions/installFlags"
-        },
-        "name": {
-          "description": "Name not required when using resourceful API",
-          "type": "string",
-          "x-go-name": "Name",
-          "example": "mysql"
         },
         "values": {
           "type": "object",
@@ -688,124 +553,6 @@
       "x-go-name": "Response",
       "x-go-package": "github.com/gojekfarm/albatross/api/list"
     },
-    "listRequestBody": {
-      "description": "Request is body of List Route",
-      "type": "object",
-      "required": [
-        "namespace"
-      ],
-      "properties": {
-        "all-namespaces": {
-          "type": "boolean",
-          "x-go-name": "AllNamespaces",
-          "example": false
-        },
-        "deployed": {
-          "type": "boolean",
-          "x-go-name": "Deployed",
-          "example": false
-        },
-        "failed": {
-          "type": "boolean",
-          "x-go-name": "Failed",
-          "example": false
-        },
-        "kube_apiserver": {
-          "type": "string",
-          "x-go-name": "KubeAPIServer"
-        },
-        "kube_context": {
-          "type": "string",
-          "x-go-name": "KubeContext",
-          "example": "minikube"
-        },
-        "kube_token": {
-          "type": "string",
-          "x-go-name": "KubeToken"
-        },
-        "namespace": {
-          "type": "string",
-          "x-go-name": "Namespace",
-          "example": "default"
-        },
-        "pending": {
-          "type": "boolean",
-          "x-go-name": "Pending",
-          "example": false
-        },
-        "uninstalled": {
-          "type": "boolean",
-          "x-go-name": "Uninstalled",
-          "example": false
-        },
-        "uninstalling": {
-          "type": "boolean",
-          "x-go-name": "Uninstalling",
-          "example": false
-        }
-      },
-      "x-go-name": "Request",
-      "x-go-package": "github.com/gojekfarm/albatross/api/list"
-    },
-    "listRequestFlags": {
-      "description": "Flags contains all the params supported",
-      "type": "object",
-      "required": [
-        "namespace"
-      ],
-      "properties": {
-        "all-namespaces": {
-          "type": "boolean",
-          "x-go-name": "AllNamespaces",
-          "example": false
-        },
-        "deployed": {
-          "type": "boolean",
-          "x-go-name": "Deployed",
-          "example": false
-        },
-        "failed": {
-          "type": "boolean",
-          "x-go-name": "Failed",
-          "example": false
-        },
-        "kube_apiserver": {
-          "type": "string",
-          "x-go-name": "KubeAPIServer"
-        },
-        "kube_context": {
-          "type": "string",
-          "x-go-name": "KubeContext",
-          "example": "minikube"
-        },
-        "kube_token": {
-          "type": "string",
-          "x-go-name": "KubeToken"
-        },
-        "namespace": {
-          "type": "string",
-          "x-go-name": "Namespace",
-          "example": "default"
-        },
-        "pending": {
-          "type": "boolean",
-          "x-go-name": "Pending",
-          "example": false
-        },
-        "uninstalled": {
-          "type": "boolean",
-          "x-go-name": "Uninstalled",
-          "example": false
-        },
-        "uninstalling": {
-          "type": "boolean",
-          "x-go-name": "Uninstalling",
-          "example": false
-        }
-      },
-      "x-go-name": "Flags",
-      "x-go-package": "github.com/gojekfarm/albatross/api/list"
-    },
     "uninstallRelease": {
       "description": "Release contains metadata about a helm release object",
       "type": "object",
@@ -848,62 +595,6 @@
       "x-go-name": "Release",
       "x-go-package": "github.com/gojekfarm/albatross/api/uninstall"
     },
-    "uninstallRequestBody": {
-      "description": "Request Uninstall request body",
-      "type": "object",
-      "required": [
-        "namespace",
-        "release_name"
-      ],
-      "properties": {
-        "disable_hooks": {
-          "type": "boolean",
-          "x-go-name": "DisableHooks",
-          "example": false
-        },
-        "dry_run": {
-          "type": "boolean",
-          "x-go-name": "DryRun",
-          "example": false
-        },
-        "keep_history": {
-          "type": "boolean",
-          "x-go-name": "KeepHistory",
-          "example": false
-        },
-        "kube_apiserver": {
-          "type": "string",
-          "x-go-name": "KubeAPIServer"
-        },
-        "kube_context": {
-          "type": "string",
-          "x-go-name": "KubeContext",
-          "example": "minikube"
-        },
-        "kube_token": {
-          "type": "string",
-          "x-go-name": "KubeToken"
-        },
-        "namespace": {
-          "type": "string",
-          "x-go-name": "Namespace",
-          "example": "default"
-        },
-        "release_name": {
-          "type": "string",
-          "x-go-name": "ReleaseName",
-          "example": "mysql"
-        },
-        "timeout": {
-          "type": "integer",
-          "format": "int64",
-          "x-go-name": "Timeout",
-          "example": 300
-        }
-      },
-      "x-go-name": "Request",
-      "x-go-package": "github.com/gojekfarm/albatross/api/uninstall"
-    },
     "uninstallResponseBody": {
       "description": "Response is the body of uninstall route",
       "type": "object",
@@ -929,9 +620,6 @@
     "upgradeFlags": {
       "description": "Flags additional flags supported while upgrading a release",
       "type": "object",
-      "required": [
-        "namespace"
-      ],
       "properties": {
         "dry_run": {
           "type": "boolean",
@@ -947,19 +635,9 @@
           "type": "string",
           "x-go-name": "KubeAPIServer"
         },
-        "kube_context": {
-          "type": "string",
-          "x-go-name": "KubeContext",
-          "example": "minikube"
-        },
         "kube_token": {
           "type": "string",
           "x-go-name": "KubeToken"
-        },
-        "namespace": {
-          "type": "string",
-          "x-go-name": "Namespace",
-          "example": "default"
         },
         "version": {
           "type": "string",
@@ -1023,11 +701,6 @@
         },
         "flags": {
           "$ref": "#/definitions/upgradeFlags"
-        },
-        "name": {
-          "type": "string",
-          "x-go-name": "Name",
-          "example": "mysql"
         },
         "values": {
           "type": "object",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/gojekfarm/albatross
 go 1.13
 
 require (
-	github.com/gorilla/mux v1.7.2
+	github.com/gorilla/mux v1.8.0
+	github.com/gorilla/schema v1.2.0
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.10.0
 	gotest.tools v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,10 @@ github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33 h1:893HsJqtxp9z1S
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.2 h1:zoNxOV7WjqXptQOVngLmcSQgXmgk4NMz1HibBchjl/I=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=
+github.com/gorilla/schema v1.2.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gosuri/uitable v0.0.4 h1:IG2xLKRvErL3uhY6e1BylFzG+aJiwQviDDTfOKeKTpY=

--- a/pkg/helmcli/config/config.go
+++ b/pkg/helmcli/config/config.go
@@ -57,7 +57,7 @@ func (ac *ActionConfig) setFlags(envconfig *EnvConfig, flg *flags.GlobalFlags) e
 
 	return ac.Configuration.Init(
 		kubeClientConfig(envconfig, actionNamespace),
-		actionNamespace,
+		flg.Namespace,
 		os.Getenv("HELM_DRIVER"),
 		logger.Debugf,
 	)

--- a/pkg/helmcli/flags/flags.go
+++ b/pkg/helmcli/flags/flags.go
@@ -5,15 +5,14 @@ import "time"
 // GlobalFlags flags which give context about kubernetes cluster to connect to
 // swagger:model globalFlags
 type GlobalFlags struct {
-	// example: minikube
-	KubeContext string `json:"kube_context,omitempty"`
+	KubeContext string `json:"-"`
 	// required: false
 	KubeToken string `json:"kube_token,omitempty"`
 	// required: false
 	KubeAPIServer string `json:"kube_apiserver,omitempty"`
 	// required: true
 	// example: default
-	Namespace string `json:"namespace" schema:"namespace"`
+	Namespace string `json:"-" schema:"namespace"`
 }
 
 type UpgradeFlags struct {

--- a/pkg/helmcli/flags/flags.go
+++ b/pkg/helmcli/flags/flags.go
@@ -13,7 +13,7 @@ type GlobalFlags struct {
 	KubeAPIServer string `json:"kube_apiserver,omitempty"`
 	// required: true
 	// example: default
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace" schema:"namespace"`
 }
 
 type UpgradeFlags struct {

--- a/swagger/release.go
+++ b/swagger/release.go
@@ -14,6 +14,12 @@ type UninstallResponse struct {
 	Body uninstall.Response
 }
 
+// UninstallErrorResponse error body for uninstall action
+// swagger:model uninstallErrorResponse
+type UninstallErrorResponse struct {
+	Error string `json:"error"`
+}
+
 // UninstallRequest stub for swagger route for uninstall
 // swagger:parameters uninstallRelease
 type UninstallRequest struct {
@@ -31,6 +37,13 @@ type ListRequest struct {
 // ListResponse stub for swagger route for List
 // swagger:response listResponse
 type ListResponse struct {
+	//in: body
+	Body list.Response
+}
+
+// ListErrorResponse stub for swagger route for List
+// swagger:model listErrorResponse
+type ListErrorResponse struct {
 	//in: body
 	Body list.Response
 }
@@ -61,4 +74,10 @@ type UpgradeRequest struct {
 type UpgradeResponse struct {
 	//in: body
 	Body upgrade.Response
+}
+
+// InstallErrorResponse body of install response
+// swagger:model installResponseErrorBody
+type InstallErrorResponse struct {
+	Error string `json:"error"`
 }


### PR DESCRIPTION
Continued from #9 
#### Changes
- Have added the following routes to expose helm releases as a resource.
  - `PUT "/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}"`
  - `POST "/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}"`
  - `DELETE "/clusters/{cluster}/namespaces/{namespace}/releases/{release_name}"`
  - `GET "/clusters/{cluster}/releases"`
  - `GET "/clusters/{cluster}/namespaces/{namespace}/releases"`
- Stricter test cases
- Query parameters and Request body are better documented in the handler.
- Have deprecated the current action based routes in documentation.
- Fixed a bug to start respect query parameters for list request
#### Dependencies
- Bumped up mux to v1.8.0 (support for path based variables)
- Added gorilla/schema for query parsing.