### PR TITLE
Fix doc UI

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12,9 +12,8 @@
   "info": {
     "description": "Albatross is a helm cli wrapper and enables using helm via http calls",
     "title": "Albatross API.",
-    "version": "v1.0.1"
+    "version": "v1.0.3"
   },
-  "host": "localhost:8080",
   "paths": {
     "/clusters/{cluster}/namespaces/{namespace}/releases": {
       "get": {

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -3,7 +3,6 @@
 // Albatross is a helm cli wrapper and enables using helm via http calls
 //
 //     Schemes: http
-//     Host: localhost:8080
 //     Version: v1.0.1
 //
 //     Consumes:

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -3,7 +3,7 @@
 // Albatross is a helm cli wrapper and enables using helm via http calls
 //
 //     Schemes: http
-//     Version: v1.0.1
+//     Version: v1.0.3
 //
 //     Consumes:
 //     - application/json


### PR DESCRIPTION
- Swagger doc wasn't usable from non localhost url due to hardcoded host.
- Removed hardcoded host