### PR TITLE
Fix validation, logging errors for release name for install endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Albatross wraps the helm package to expose helm operations as HTTP APIs.
 ### Prerequisites
 * Go >= version 1.12
 * Make sure gomodules is enabled(GO111MODULES=on) if the source path is part of GOPATH
+* Install [go-swagger](https://goswagger.io/install.html)
 
 ### Building from source
 Clone the repository and run:

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -12,7 +12,7 @@
   "info": {
     "description": "Albatross is a helm cli wrapper and enables using helm via http calls",
     "title": "Albatross API.",
-    "version": "v1.1.0"
+    "version": "v1.2.0"
   },
   "paths": {
     "/clusters/{cluster}/namespaces/{namespace}/releases": {

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -3,7 +3,7 @@
 // Albatross is a helm cli wrapper and enables using helm via http calls
 //
 //     Schemes: http
-//     Version: v1.1.0
+//     Version: v1.2.0
 //
 //     Consumes:
 //     - application/json


### PR DESCRIPTION
1. Fix error logging statement structure in install API
2. Remove redundant validations on release name because the validation is already happening underlying helm install function
3. Add test to validate error for validating releasename based on Regex